### PR TITLE
Bugfix

### DIFF
--- a/PicoProducer/python/analysis/utils.py
+++ b/PicoProducer/python/analysis/utils.py
@@ -347,8 +347,7 @@ def getlepvetoes(event, electrons, muons, taus, channel):
     if abs(electron.dxy)>0.045: continue
     if electron.pfRelIso03_all>0.3: continue
     if any(electron.DeltaR(tau)<0.4 for tau in taus): continue
-    if all(e._index!=electron._index for e in electrons): continue
-    if electron.convVeto==1 and electron.lostHits<=1 and electron.mvaFall17V2Iso_WP90:
+    if electron.convVeto==1 and electron.lostHits<=1 and electron.mvaFall17V2Iso_WP90 and all(e._index!=electron._index for e in electrons):
       extraelec_veto = True
     if electron.pt>15 and electron.cutBased>0 and electron.mvaFall17V2Iso_WPL:
       looseElectrons.append(electron)


### PR DESCRIPTION
I believe this line should be checking that the electron being looked at isn't the one used in the final state, but in this line it skips the electron if it's indeed not the FS electron. There's a similar line above for muons, but it doesn't follow with a continue.