### PR TITLE
Run3 crosssections

### DIFF
--- a/Plotter/config/samples_v12.py
+++ b/Plotter/config/samples_v12.py
@@ -38,7 +38,7 @@ def getsampleset(channel,era,**kwargs):
     if '2022_preEE' in era:
       expsamples = [ # table of MC samples to be converted to Sample objects
         # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
-        ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, in principle it should be possible to conbine this sample with the inclusive one below 
+        #( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, commenting this one out as it is the same as the one below but in principle it should be possible to conbine this sample with the inclusive one below 
         ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor
         #( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      978.3*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor # currently not available
         ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      315.1*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
@@ -71,7 +71,7 @@ def getsampleset(channel,era,**kwargs):
     if '2022_postEE' in era:
       expsamples = [ # table of MC samples to be converted to Sample objects
         # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
-        ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, in principle it should be possible to conbine this sample with the inclusive one below 
+        #( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, commenting this one out as it is the same as the one below but in principle it should be possible to conbine this sample with the inclusive one below 
         ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor
         ( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      978.3*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor currently not available
         ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      315.1*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
@@ -148,9 +148,8 @@ def getsampleset(channel,era,**kwargs):
   
   # STITCH
   # Note: titles are set via STYLE.sample_titles
-  sampleset.stitch("W*Jets",    incl='WJ',  name='WJ'     ) # W + jets
-  sampleset.stitch("DY*J*M-50", incl='DYJ', name="DY_M50" ) # Drell-Yan, M > 50 GeV
-  #sampleset.stitch("DY*J*M-10to50", incl='DYJ', name="DY_M10to50" )
+  sampleset.stitch("W*LNu*",    incl='WJ',  name='WJ'     ) # W + jets
+  sampleset.stitch("DYto2L-4Jets_MLL-50*", incl='DYJ', name="DY_M50" ) # Drell-Yan, M > 50 GeV
   
   # JOIN
   sampleset.join('DY', name='DY' ) # Drell-Yan, M < 50 GeV + M > 50 GeV

--- a/Plotter/config/samples_v12.py
+++ b/Plotter/config/samples_v12.py
@@ -64,10 +64,10 @@ def getsampleset(channel,era,**kwargs):
         ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",          15.9, {"nevts" : 1.0} ), # NLO (36.1) times LNu2Q BR
         ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                3.8, {"nevts" : 1.0} ), # NLO (36.1) times 2L2Nu BR
       ]
-      if 'mutau' in channel:
-        expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
-        # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
-        # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
+     # if 'mutau' in channel:
+     #   expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
+     #   # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
+     #   # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
     if '2022_postEE' in era:
       expsamples = [ # table of MC samples to be converted to Sample objects
         # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
@@ -97,10 +97,10 @@ def getsampleset(channel,era,**kwargs):
         ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",          15.9, {"nevts" : 1.0} ), # NLO (36.1) times LNu2Q BR
         ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                3.8, {"nevts" : 1.0} ), # NLO (36.1) times 2L2Nu BR
       ]
-      if 'mutau' in channel:
-        expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
-        # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
-        # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
+     # if 'mutau' in channel:
+     #   expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
+     #   # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
+     #   # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
   else:
     LOG.throw(IOError,"Did not recognize era %r!"%(era))
   

--- a/Plotter/config/samples_v12.py
+++ b/Plotter/config/samples_v12.py
@@ -28,45 +28,46 @@ def getsampleset(channel,era,**kwargs):
   if '2022_preEE' in era or '2022_postEE' in era: # so far same samples and cross sections are used for preEE and postEE, if event numbers are set elsewhere then we don't need to add seperate numbers for both eras
     # for now nevts is set to 1 so it isn't taken into account in the scaling of the samples as this will be done elsewhere
     
-    kfactor_dy=1.12296 # LO->NNLO+NLO_EW k-factor computed for 13.6 TeV
-    kfactor_wj=1.12555 # LO->NNLO+NLO_EW k-factor computed for 13.6 TeV
+    kfactor_dy=6282.6/5455.0 # LO->NNLO+NLO_EW k-factor computed for 13.6 TeV
+    kfactor_wj=63425.1/55300 # LO->NNLO+NLO_EW k-factor computed for 13.6 TeV
     kfactor_ttbar=923.6/762.1 # NLO->NNLO k-factor computed for 13.6 TeV
     kfactor_ww=1.524 # LO->NNLO+NLO_EW computed for 13.6 TeV
     kfactor_zz=1.524 # LO->NNLO+NLO_EW computed for 13.6 TeV
     kfactor_wz=1.414 # LO->NNLO+NLO_EW computed for 13.6 TeV 
 
+    # need check check sample names below match ouput of NanoProd:
     expsamples = [ # table of MC samples to be converted to Sample objects
       # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
-      ( 'DY', "DYTo2L_MLL-4to50",   "Drell-Yan 4-50",    100900.0, {"nevts" : 1.0}), # LO, need to check where k-factor is applied
-      ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5558.0, {'extraweight': dyweight, "nevts":1.0} ), # LO, apply k-factor in stitching
-      ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5558.0, {'extraweight': dyweight, "nevts":1.0} ), # LO, apply k-factor in stitching, in principle this sample should be the same as the inclusive one above so should be able to combine stats - to be checked
-      ( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
-      ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
-      ( 'DY', "DYto2L-4Jets_MLL-50_3J",      "Drell-Yan 3J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
-      ( 'DY', "DYto2L-4Jets_MLL-50_4J",      "Drell-Yan 4J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
-      ( 'WJ', "WJetsToLNu-4Jets",            "W + jets",           55300., {"nevts" : 1.0} ), # LO, apply k-factor in stitching
-      ( 'WJ', "WJetsToLNu-4Jets_1J",           "W + 1J",              9128., {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
-      ( 'WJ', "WJetsToLNu-4Jets_2J",           "W + 2J",              2922., {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
-      ( 'WJ', "WJetsToLNu-4Jets_3J",           "W + 3J",               861.3, {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
-      ( 'WJ', "WJetsToLNu-4Jets_4J",           "W + 4J",               -, {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
+      ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, in principle it should be possible to conbine this sample with the inclusive one below 
+      ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor
+      ( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      978.3*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+      ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      315.1*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+      ( 'DY', "DYto2L-4Jets_MLL-50_3J",      "Drell-Yan 3J 50",      93.7*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+      ( 'DY', "DYto2L-4Jets_MLL-50_4J",      "Drell-Yan 4J 50",      45.4*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+      ( 'WJ', "WJetsToLNu-4Jets",            "W + jets",           55300.*kfactor_wj, {"nevts" : 1.0} ), # LO times kfactor
+      ( 'WJ', "WJetsToLNu-4Jets_1J",           "W + 1J",              9128.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+      ( 'WJ', "WJetsToLNu-4Jets_2J",           "W + 2J",              2922.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+      ( 'WJ', "WJetsToLNu-4Jets_3J",           "W + 3J",               861.3*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+      ( 'WJ', "WJetsToLNu-4Jets_4J",           "W + 4J",               415.4*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
    
       ( 'VV', "WW",             "WW",                    80.23*kfactor_ww,{"nevts" :  1.0} ), # LO times kfactor
       ( 'VV', "WZ",             "WZ",                    29.1*kfactor_wz,{"nevts" :  1.0} ), # LO times kfactor
       ( 'VV', "ZZ",             "ZZ",                    12.75*kfactor_zz,{"nevts" :  1.0} ), # LO times kfactor
 
-      ( 'TT', "TTTo2L2Nu",             "ttbar 2l2#nu",          80.9*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR from Run-2 samples times kfactor
-      ( 'TT', "TTto4Q",                "ttbar hadronic",       346.4*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR from Run-2 samples times kfactor
-      ( 'TT', "TTtoLNu2Q",             "ttbar semileptonic",   334.8*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR from Run-2 samples times kfactor
-      # got to here
-      ( 'ST', "TBbarQ_t-channel",      "ST t-channel t",       136.02, {"nevts" : 1.0} ),
-      ( 'ST', "TbarBQ_t-channel",  "ST t-channel at",       80.95, {"nevts" : 1.0} ),
-      ( 'ST', "TWminustoLNu2Q",             "ST tW semileptonic",                 35.85, {"nevts" : 1.0} ),
-      ( 'ST', "TWminusto2L2Nu",             "ST tW 2l2#nu",                 35.85, {"nevts" : 1.0} ),
-      ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",                35.85, {"nevts" : 1.0} ),
-      ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                35.85, {"nevts" : 1.0} ),
+      ( 'TT', "TTTo2L2Nu",             "ttbar 2l2#nu",          80.9*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+      ( 'TT', "TTto4Q",                "ttbar hadronic",       346.4*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+      ( 'TT', "TTtoLNu2Q",             "ttbar semileptonic",   334.8*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+      ( 'ST', "TBbarQ_t-channel",      "ST t-channel t",       123.8, {"nevts" : 1.0} ), # NLO
+      ( 'ST', "TbarBQ_t-channel",  "ST t-channel at",       75.47, {"nevts" : 1.0} ), # NLO
+      ( 'ST', "TWminustoLNu2Q",             "ST tW semileptonic",                 15.8, {"nevts" : 1.0} ), # NLO (36.0) times LNu2Q BR
+      ( 'ST', "TWminusto2L2Nu",             "ST tW 2l2#nu",                 3.8, {"nevts" : 1.0} ), # NLO (36.0) times 2L2Nu BR
+      ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",          15.9, {"nevts" : 1.0} ), # NLO (36.1) times LNu2Q BR
+      ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                3.8, {"nevts" : 1.0} ), # NLO (36.1) times 2L2Nu BR
     ]
     if 'mutau' in channel:
-      expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5558.0,{'extraweight': dyweight})) # LO (does not include filter eff), apply k-factor in stitching, apply correct normalization in stitching
+      expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
+      # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
+      # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
   else:
     LOG.throw(IOError,"Did not recognize era %r!"%(era))
   

--- a/Plotter/config/samples_v12.py
+++ b/Plotter/config/samples_v12.py
@@ -1,0 +1,159 @@
+# Description: Common configuration file for creating pico sample set plotting scripts
+import re
+from TauFW.Plotter.sample.utils import LOG, STYLE, ensuredir, repkey, joincuts, joinweights, ensurelist,\
+                                       setera, getyear, loadmacro, Sel, Var
+from TauFW.Plotter.sample.utils import getsampleset as _getsampleset
+
+def getsampleset(channel,era,**kwargs):
+  verbosity = LOG.getverbosity(kwargs)
+  year     = getyear(era) # get integer year
+  fname    = kwargs.get('fname', "$PICODIR/$SAMPLE_$CHANNEL$TAG.root" ) # file name pattern of pico files
+  split    = kwargs.get('split',    ['DY'] if 'tau' in channel else [ ] ) # split samples (e.g. DY) into genmatch components
+  join     = kwargs.get('join',     ['VV','Top'] ) # join samples (e.g. VV, top)
+  rmsfs    = ensurelist(kwargs.get('rmsf', [ ])) # remove the tau ID SF, e.g. rmsf=['idweight_2','ltfweight_2']
+  addsfs   = ensurelist(kwargs.get('addsf', [ ])) # add extra weight to all samples
+  weight   = kwargs.get('weight',   None         ) # weight for all MC samples
+  dyweight = kwargs.get('dyweight', 'zptweight'  ) # weight for DY samples
+  ttweight = kwargs.get('ttweight', 'ttptweight' ) # weight for ttbar samples
+  filter   = kwargs.get('filter',   None         ) # only include these MC samples
+  vetoes   = kwargs.get('vetoes',   None         ) # veto these MC samples
+  #tag      = kwargs.get('tag',      ""           ) # extra tag for sample file names
+  table    = kwargs.get('table',    True         ) # print sample set table
+  setera(era) # set era for plot style and lumi-xsec normalization
+  if 'TT' in split and 'Top' in join: # don't join TT & ST
+    join.remove('Top')
+    join += ['TT','ST']
+  
+  # SM BACKGROUND MC SAMPLES
+  if '2022_preEE' in era or '2022_postEE' in era: # so far same samples and cross sections are used for preEE and postEE, if event numbers are set elsewhere then we don't need to add seperate numbers for both eras
+    # for now nevts is set to 1 so it isn't taken into account in the scaling of the samples as this will be done elsewhere
+    
+    kfactor_dy=1.12296 # LO->NNLO+NLO_EW k-factor computed for 13.6 TeV
+    kfactor_wj=1.12555 # LO->NNLO+NLO_EW k-factor computed for 13.6 TeV
+    kfactor_ttbar=923.6/762.1 # NLO->NNLO k-factor computed for 13.6 TeV
+    kfactor_ww=1.524 # LO->NNLO+NLO_EW computed for 13.6 TeV
+    kfactor_zz=1.524 # LO->NNLO+NLO_EW computed for 13.6 TeV
+    kfactor_wz=1.414 # LO->NNLO+NLO_EW computed for 13.6 TeV 
+
+    expsamples = [ # table of MC samples to be converted to Sample objects
+      # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
+      ( 'DY', "DYTo2L_MLL-4to50",   "Drell-Yan 4-50",    100900.0, {"nevts" : 1.0}), # LO, need to check where k-factor is applied
+      ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5558.0, {'extraweight': dyweight, "nevts":1.0} ), # LO, apply k-factor in stitching
+      ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5558.0, {'extraweight': dyweight, "nevts":1.0} ), # LO, apply k-factor in stitching, in principle this sample should be the same as the inclusive one above so should be able to combine stats - to be checked
+      ( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
+      ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
+      ( 'DY', "DYto2L-4Jets_MLL-50_3J",      "Drell-Yan 3J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
+      ( 'DY', "DYto2L-4Jets_MLL-50_4J",      "Drell-Yan 4J 50",      -, {'extraweight': dyweight, "nevts": 1.0} ), # LO, apply k-factor in stitching
+      ( 'WJ', "WJetsToLNu-4Jets",            "W + jets",           55300., {"nevts" : 1.0} ), # LO, apply k-factor in stitching
+      ( 'WJ', "WJetsToLNu-4Jets_1J",           "W + 1J",              9128., {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
+      ( 'WJ', "WJetsToLNu-4Jets_2J",           "W + 2J",              2922., {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
+      ( 'WJ', "WJetsToLNu-4Jets_3J",           "W + 3J",               861.3, {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
+      ( 'WJ', "WJetsToLNu-4Jets_4J",           "W + 4J",               -, {"nevts" : 1.0}  ), # LO, apply k-factor in stitching
+   
+      ( 'VV', "WW",             "WW",                    80.23*kfactor_ww,{"nevts" :  1.0} ), # LO times kfactor
+      ( 'VV', "WZ",             "WZ",                    29.1*kfactor_wz,{"nevts" :  1.0} ), # LO times kfactor
+      ( 'VV', "ZZ",             "ZZ",                    12.75*kfactor_zz,{"nevts" :  1.0} ), # LO times kfactor
+
+      ( 'TT', "TTTo2L2Nu",             "ttbar 2l2#nu",          80.9*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR from Run-2 samples times kfactor
+      ( 'TT', "TTto4Q",                "ttbar hadronic",       346.4*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR from Run-2 samples times kfactor
+      ( 'TT', "TTtoLNu2Q",             "ttbar semileptonic",   334.8*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR from Run-2 samples times kfactor
+      # got to here
+      ( 'ST', "TBbarQ_t-channel",      "ST t-channel t",       136.02, {"nevts" : 1.0} ),
+      ( 'ST', "TbarBQ_t-channel",  "ST t-channel at",       80.95, {"nevts" : 1.0} ),
+      ( 'ST', "TWminustoLNu2Q",             "ST tW semileptonic",                 35.85, {"nevts" : 1.0} ),
+      ( 'ST', "TWminusto2L2Nu",             "ST tW 2l2#nu",                 35.85, {"nevts" : 1.0} ),
+      ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",                35.85, {"nevts" : 1.0} ),
+      ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                35.85, {"nevts" : 1.0} ),
+    ]
+    if 'mutau' in channel:
+      expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5558.0,{'extraweight': dyweight})) # LO (does not include filter eff), apply k-factor in stitching, apply correct normalization in stitching
+  else:
+    LOG.throw(IOError,"Did not recognize era %r!"%(era))
+  
+  # OBSERVED DATA SAMPLES
+  if   'tautau' in channel: dataset = "Tau_Run%d?"%year
+  elif 'mutau'  in channel: dataset = "SingleMuon_Run%d?"%year
+  elif 'etau'   in channel: dataset = "EGamma_Run%d?"%year if year==2018 else "SingleElectron_Run%d?"%year
+  elif 'mumu'   in channel: dataset = "SingleMuon_Run%d?"%year
+  elif 'emu'    in channel: dataset = "SingleMuon_Run%d?"%year
+  elif 'ee'     in channel: dataset = "EGamma_Run%d?"%year if year==2018 else "SingleElectron_Run%d?"%year
+  else:
+    LOG.throw(IOError,"Did not recognize channel %r!"%(channel))
+  datasample = ('Data',dataset) # GROUP, NAME
+  
+  # FILTER
+  if filter:
+    expsamples = [s for s in expsamples if any(f in s[0] for f in filter)]
+  if vetoes:
+    expsamples = [s for s in expsamples if not any(v in s[0] for v in vetoes)]
+  
+  # SAMPLE SET
+  if weight=="":
+    weight = ""
+  #elif channel in ['mutau','etau']:
+  if 'mutau' in channel or 'etau' in channel:
+    weight = "np.sign(genweight)*trigweight*puweight*idisoweight_1*idweight_2*ltfweight_2"
+  elif channel in ['tautau','ditau']:
+    weight = "genweight*trigweight*puweight*idweight_1*idweight_2*ltfweight_1*ltfweight_2"
+  else: # mumu, emu, ...
+    weight = "np.sign(genweight)*trigweight*puweight*idisoweight_1*idisoweight_2"
+  for sf in rmsfs: # remove (old) SFs, e.g. for SF measurement
+    weight = weight.replace(sf,"").replace("**","*").strip('*')
+  for sf in addsfs:  # add extra SFs, e.g. for SF measurement
+    weight = joinweights(weight,sf)
+  kwargs.setdefault('weight',weight) # common weight for MC
+  kwargs.setdefault('fname', fname)  # default filename pattern
+  sampleset = _getsampleset(datasample,expsamples,channel=channel,era=era,**kwargs)
+  LOG.verb("weight = %r"%(weight),verbosity,1)
+  
+  # STITCH
+  # Note: titles are set via STYLE.sample_titles
+  sampleset.stitch("W*Jets",    incl='WJ',  name='WJ'     ) # W + jets
+  sampleset.stitch("DY*J*M-50", incl='DYJ', name="DY_M50" ) # Drell-Yan, M > 50 GeV
+  #sampleset.stitch("DY*J*M-10to50", incl='DYJ', name="DY_M10to50" )
+  
+  # JOIN
+  sampleset.join('DY', name='DY' ) # Drell-Yan, M < 50 GeV + M > 50 GeV
+  if 'VV' in join:
+    sampleset.join('VV','WZ','WW','ZZ', name='VV' ) # Diboson
+  if 'TT' in join and era!='year':
+    sampleset.join('TT', name='TT' ) # ttbar
+  if 'ST' in join:
+    sampleset.join('ST', name='ST' ) # single top
+  if 'Top' in join:
+    sampleset.join('TT','ST', name='Top' ) # ttbar + single top
+  
+  # SPLIT
+  # Note: titles are set via STYLE.sample_titles
+  if split and channel.count('tau')==1:
+    ZTT = STYLE.sample_titles.get('ZTT',"Z -> %s"%channel) # title
+    if channel.count('tau')==1:
+      ZTT = ZTT.replace("{l}","{mu}" if "mu" in channel else "{e}")
+      GMR = "genmatch_2==5"
+      GML = "genmatch_2>0 && genmatch_2<5"
+      GMJ = "genmatch_2==0"
+      GMF = "genmatch_2<5"
+    elif channel.count('tau')==2:
+      ZTT = ZTT.replace("{l}","{h}")
+      GMR = "genmatch_1==5 && genmatch_2==5"
+      GML = "(genmatch_1<5 || genmatch_2<5) && genmatch_1>0 && genmatch_2>0"
+      GMJ = "(genmatch_1==0 || genmatch_2==0)"
+      GMF = "(genmatch_1<5 || genmatch_2<5)"
+    else:
+      LOG.throw(IOError,"Did not recognize channel %r!"%(channel))
+    if 'DM' in split: # split DY by decay modes
+      samples.split('DY', [('ZTTDM0', ZTT+", h^{#pm}",                   GMR+" && dm_2==0"),
+                           ('ZTTDM1', ZTT+", h^{#pm}h^{0}",              GMR+" && dm_2==1"),
+                           ('ZTTDM10',ZTT+", h^{#pm}h^{#mp}h^{#pm}",     GMR+" && dm_2==10"),
+                           ('ZTTDM11',ZTT+", h^{#pm}h^{#mp}h^{#pm}h^{0}",GMR+" && dm_2==11"),
+                           ('ZL',GML),('ZJ',GMJ),])
+    elif 'DY' in split:
+      sampleset.split('DY',[('ZTT',ZTT,GMR),('ZL',GML),('ZJ',GMJ),])
+    if 'TT' in split:
+      sampleset.split('TT',[('TTT',GMR),('TTJ',GMF),])
+  
+  if table:
+    sampleset.printtable(merged=True,split=True)
+  print(">>> common weight: %r"%(weight))
+  return sampleset
+  

--- a/Plotter/config/samples_v12.py
+++ b/Plotter/config/samples_v12.py
@@ -35,45 +35,84 @@ def getsampleset(channel,era,**kwargs):
     kfactor_zz=1.524 # LO->NNLO+NLO_EW computed for 13.6 TeV
     kfactor_wz=1.414 # LO->NNLO+NLO_EW computed for 13.6 TeV 
 
-    # need check check sample names below match ouput of NanoProd:
-    expsamples = [ # table of MC samples to be converted to Sample objects
-      # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
-      ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, in principle it should be possible to conbine this sample with the inclusive one below 
-      ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor
-      ( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      978.3*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
-      ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      315.1*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
-      ( 'DY', "DYto2L-4Jets_MLL-50_3J",      "Drell-Yan 3J 50",      93.7*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
-      ( 'DY', "DYto2L-4Jets_MLL-50_4J",      "Drell-Yan 4J 50",      45.4*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
-      ( 'WJ', "WJetsToLNu-4Jets",            "W + jets",           55300.*kfactor_wj, {"nevts" : 1.0} ), # LO times kfactor
-      ( 'WJ', "WJetsToLNu-4Jets_1J",           "W + 1J",              9128.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
-      ( 'WJ', "WJetsToLNu-4Jets_2J",           "W + 2J",              2922.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
-      ( 'WJ', "WJetsToLNu-4Jets_3J",           "W + 3J",               861.3*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
-      ( 'WJ', "WJetsToLNu-4Jets_4J",           "W + 4J",               415.4*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
-   
-      ( 'VV', "WW",             "WW",                    80.23*kfactor_ww,{"nevts" :  1.0} ), # LO times kfactor
-      ( 'VV', "WZ",             "WZ",                    29.1*kfactor_wz,{"nevts" :  1.0} ), # LO times kfactor
-      ( 'VV', "ZZ",             "ZZ",                    12.75*kfactor_zz,{"nevts" :  1.0} ), # LO times kfactor
+    if '2022_preEE' in era:
+      expsamples = [ # table of MC samples to be converted to Sample objects
+        # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
+        ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, in principle it should be possible to conbine this sample with the inclusive one below 
+        ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor
+        #( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      978.3*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor # currently not available
+        ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      315.1*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+        ( 'DY', "DYto2L-4Jets_MLL-50_3J",      "Drell-Yan 3J 50",      93.7*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+        ( 'DY', "DYto2L-4Jets_MLL-50_4J",      "Drell-Yan 4J 50",      45.4*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+        ( 'WJ', "WJetsToLNu-4Jets",            "W + jets",           55300.*kfactor_wj, {"nevts" : 1.0} ), # LO times kfactor
+        #( 'WJ', "WJetsToLNu-4Jets_1J",           "W + 1J",              9128.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor # currently not available
+        #( 'WJ', "WJetsToLNu-4Jets_2J",           "W + 2J",              2922.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor # currently not available
+        ( 'WJ', "WJetsToLNu-4Jets_3J",           "W + 3J",               861.3*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+        ( 'WJ', "WJetsToLNu-4Jets_4J",           "W + 4J",               415.4*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+     
+        ( 'VV', "WW",             "WW",                    80.23*kfactor_ww,{"nevts" :  1.0} ), # LO times kfactor
+        ( 'VV', "WZ",             "WZ",                    29.1*kfactor_wz,{"nevts" :  1.0} ), # LO times kfactor
+        ( 'VV', "ZZ",             "ZZ",                    12.75*kfactor_zz,{"nevts" :  1.0} ), # LO times kfactor
 
-      ( 'TT', "TTTo2L2Nu",             "ttbar 2l2#nu",          80.9*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
-      ( 'TT', "TTto4Q",                "ttbar hadronic",       346.4*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
-      ( 'TT', "TTtoLNu2Q",             "ttbar semileptonic",   334.8*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
-      ( 'ST', "TBbarQ_t-channel",      "ST t-channel t",       123.8, {"nevts" : 1.0} ), # NLO
-      ( 'ST', "TbarBQ_t-channel",  "ST t-channel at",       75.47, {"nevts" : 1.0} ), # NLO
-      ( 'ST', "TWminustoLNu2Q",             "ST tW semileptonic",                 15.8, {"nevts" : 1.0} ), # NLO (36.0) times LNu2Q BR
-      ( 'ST', "TWminusto2L2Nu",             "ST tW 2l2#nu",                 3.8, {"nevts" : 1.0} ), # NLO (36.0) times 2L2Nu BR
-      ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",          15.9, {"nevts" : 1.0} ), # NLO (36.1) times LNu2Q BR
-      ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                3.8, {"nevts" : 1.0} ), # NLO (36.1) times 2L2Nu BR
-    ]
-    if 'mutau' in channel:
-      expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
-      # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
-      # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
+        ( 'TT', "TTTo2L2Nu",             "ttbar 2l2#nu",          80.9*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+        ( 'TT', "TTto4Q",                "ttbar hadronic",       346.4*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+        ( 'TT', "TTtoLNu2Q",             "ttbar semileptonic",   334.8*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+        ( 'ST', "TBbarQ_t-channel",      "ST t-channel t",       123.8, {"nevts" : 1.0} ), # NLO
+        ( 'ST', "TbarBQ_t-channel",  "ST t-channel at",       75.47, {"nevts" : 1.0} ), # NLO
+        ( 'ST', "TWminustoLNu2Q",             "ST tW semileptonic",                 15.8, {"nevts" : 1.0} ), # NLO (36.0) times LNu2Q BR
+        ( 'ST', "TWminusto2L2Nu",             "ST tW 2l2#nu",                 3.8, {"nevts" : 1.0} ), # NLO (36.0) times 2L2Nu BR
+        ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",          15.9, {"nevts" : 1.0} ), # NLO (36.1) times LNu2Q BR
+        ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                3.8, {"nevts" : 1.0} ), # NLO (36.1) times 2L2Nu BR
+      ]
+      if 'mutau' in channel:
+        expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
+        # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
+        # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
+    if '2022_postEE' in era:
+      expsamples = [ # table of MC samples to be converted to Sample objects
+        # GROUP NAME                     TITLE                 XSEC      EXTRA OPTIONS
+        ( 'DY', "DYJetsToLL_M-50",       "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor, in principle it should be possible to conbine this sample with the inclusive one below 
+        ( 'DY', "DYto2L-4Jets_MLL-50",   "Drell-Yan 50",        5455.0*kfactor_dy, {'extraweight': dyweight, "nevts":1.0} ), # LO times kfactor
+        ( 'DY', "DYto2L-4Jets_MLL-50_1J",      "Drell-Yan 1J 50",      978.3*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor currently not available
+        ( 'DY', "DYto2L-4Jets_MLL-50_2J",      "Drell-Yan 2J 50",      315.1*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+        ( 'DY', "DYto2L-4Jets_MLL-50_3J",      "Drell-Yan 3J 50",      93.7*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+        ( 'DY', "DYto2L-4Jets_MLL-50_4J",      "Drell-Yan 4J 50",      45.4*kfactor_dy, {'extraweight': dyweight, "nevts": 1.0} ), # LO times kfactor
+        ( 'WJ', "WtoLNu-4Jets",            "W + jets",           55300.*kfactor_wj, {"nevts" : 1.0} ), # LO times kfactor
+        ( 'WJ', "WJetstoLNu-4Jets_1J",           "W + 1J",              9128.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+        ( 'WJ', "WJetstoLNu-4Jets_2J",           "W + 2J",              2922.*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+        ( 'WJ', "WJetstoLNu-4Jets_3J",           "W + 3J",               861.3*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+        ( 'WJ', "WtoLNu-4Jets_4J",           "W + 4J",               415.4*kfactor_wj, {"nevts" : 1.0}  ), # LO times kfactor
+   
+        ( 'VV', "WW",             "WW",                    80.23*kfactor_ww,{"nevts" :  1.0} ), # LO times kfactor
+        ( 'VV', "WZ",             "WZ",                    29.1*kfactor_wz,{"nevts" :  1.0} ), # LO times kfactor
+        ( 'VV', "ZZ",             "ZZ",                    12.75*kfactor_zz,{"nevts" :  1.0} ), # LO times kfactor
+
+        ( 'TT', "TTTo2L2Nu",             "ttbar 2l2#nu",          80.9*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+        ( 'TT', "TTto4Q",                "ttbar hadronic",       346.4*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+        ( 'TT', "TTtoLNu2Q",             "ttbar semileptonic",   334.8*kfactor_ttbar, {'extraweight': ttweight, "nevts" : 1.0} ), # NLO times BR times kfactor
+        ( 'ST', "TBbarQ_t-channel",      "ST t-channel t",       123.8, {"nevts" : 1.0} ), # NLO
+        ( 'ST', "TbarBQ_t-channel",  "ST t-channel at",       75.47, {"nevts" : 1.0} ), # NLO
+        ( 'ST', "TWminustoLNu2Q",             "ST tW semileptonic",                 15.8, {"nevts" : 1.0} ), # NLO (36.0) times LNu2Q BR
+        ( 'ST', "TWminusto2L2Nu",             "ST tW 2l2#nu",                 3.8, {"nevts" : 1.0} ), # NLO (36.0) times 2L2Nu BR
+        ( 'ST', "TbarWplustoLNu2Q",         "ST atW semileptonic",          15.9, {"nevts" : 1.0} ), # NLO (36.1) times LNu2Q BR
+        ( 'ST', "TbarWplusto2L2Nu",         "ST atW 2l2#nu",                3.8, {"nevts" : 1.0} ), # NLO (36.1) times 2L2Nu BR
+      ]
+      if 'mutau' in channel:
+        expsamples.append(('DY',"DYto2TautoMuTauh_M-50","Drell-Yan 50 -> tautau -> mu+tauh",5455.0*kfactor_dy,{'extraweight': dyweight})) # LO (using same cross section as inclusive samples), apply correct normalization in stitching
+        # the cross section for this exact samples is 1885.0 which is ~ 1/3 the total DY->LL cross section (expected since it only selects taus and not electrons and muons)
+        # the filter efficiency for this sample (due to tau BRs + kinematic cuts on tau decay products) is 2.865e-02 
   else:
     LOG.throw(IOError,"Did not recognize era %r!"%(era))
   
   # OBSERVED DATA SAMPLES
   if   'tautau' in channel: dataset = "Tau_Run%d?"%year
-  elif 'mutau'  in channel: dataset = "SingleMuon_Run%d?"%year
+  elif 'mutau'  in channel:
+    if era=='2022_preEE':
+      dataset = "Muon_Run%d?"%year 
+      #dataset = "SingleMuon_Run%d?"%year # need this one as well for C
+      # TODO: need to somehow handle that we need SingleMuonC, MuonC, and MuonD for preEE
+    elif era=='2022_postEE': dataset = "Muon_Run%d?"%year
+    else: dataset = "SingleMuon_Run%d?"%year
   elif 'etau'   in channel: dataset = "EGamma_Run%d?"%year if year==2018 else "SingleElectron_Run%d?"%year
   elif 'mumu'   in channel: dataset = "SingleMuon_Run%d?"%year
   elif 'emu'    in channel: dataset = "SingleMuon_Run%d?"%year

--- a/Plotter/python/sample/utils.py
+++ b/Plotter/python/sample/utils.py
@@ -382,7 +382,7 @@ def stitch(samplelist,*searchterms,**kwargs):
   name      = kwargs.get('name',      searchterms[0] )
   name_incl = kwargs.get('incl',      searchterms[0] ) # name of inclusive sample
   xsec_incl = kwargs.get('xsec',      None           ) # (N)NLO cross section to compute k-factor
-  kfactor   = kwargs.get('kfactor',   None           ) # k-factor
+  kfactor   = kwargs.get('kfactor',   1.          ) # k-factor
   cme = kwargs.get('cme',13.6) # COM energy
 
   verbosity = 2

--- a/Plotter/python/sample/utils.py
+++ b/Plotter/python/sample/utils.py
@@ -14,7 +14,7 @@ gROOT.SetBatch(True)
 LOG  = Logger('Sample')
 era  = None # data period: 2016, 2017, 2018, ...
 lumi = -1   # integrated luminosity [fb-1]
-cme  = 13   # center-of-mass energy [TeV]
+cme  = 13.6   # center-of-mass energy [TeV]
 xsecs_nlo = { # NLO cross sections to compute k-factor for stitching
   'DYJetsToLL_M-50':     3*2025.74, # NNLO, FEWZ
   'DYJetsToLL_M-10to50':  18610.0, # NLO, aMC@NLO
@@ -147,7 +147,7 @@ def setera(era_,lumi_=None,**kwargs):
       lumi = CMSStyle.lumi_dict.get(year,None)
   else:
     kwargs['lumi'] = lumi
-  cme = kwargs.get('cme',13)
+  cme = kwargs.get('cme',13.6)
   CMSStyle.setCMSEra(era,**kwargs)
   LOG.verb("setera: era = %r, lumi = %r/fb, cme = %r TeV"%(era,lumi,cme),kwargs,2)
   if not lumi or lumi<0:
@@ -383,6 +383,7 @@ def stitch(samplelist,*searchterms,**kwargs):
   name_incl = kwargs.get('incl',      searchterms[0] ) # name of inclusive sample
   xsec_incl = kwargs.get('xsec',      None           ) # (N)NLO cross section to compute k-factor
   kfactor   = kwargs.get('kfactor',   None           ) # k-factor
+  cme = kwargs.get('cme',13.6) # COM energy
 
   verbosity = 2
   ###### NanoAOD efficiencies -- currently hard-coded
@@ -434,7 +435,10 @@ def stitch(samplelist,*searchterms,**kwargs):
   xsec_incl_LO    = sample_incl.xsec
   if kfactor:
     xsec_incl_NLO = kfactor*xsec_incl_LO
-  else:
+  elif cme==13:
+    # the below procedure computes the k-factors from the xross-sections specified in xsecs_nlo above
+    # this proceudre is used only for Run-2 (13 TeV)
+    # for Run-3 (13.6 TeV) we do the kfactor scaling in the cross sections file so this is not needed
     xsec_incl_NLO = xsec_incl or getxsec_nlo(name,*searchterms) or xsec_incl_LO
     kfactor       = xsec_incl_NLO / xsec_incl_LO
   LOG.verb("  %s k-factor = %.2f = %.2f / %.2f"%(name,kfactor,xsec_incl_NLO,xsec_incl_LO),verbosity,level=2)

--- a/Plotter/python/sample/utils.py
+++ b/Plotter/python/sample/utils.py
@@ -432,21 +432,21 @@ def stitch(samplelist,*searchterms,**kwargs):
     title = sample_incl.title
 
   # Compute k-factor for NLO cross section normalisation
-  xsec_incl    = sample_incl.xsec
+  xsec_incl_initial    = sample_incl.xsec
   if kfactor:
-    xsec_incl_corrected = kfactor*xsec_incl
+    xsec_incl_corrected = kfactor*xsec_incl_initial
   elif cme==13:
     # the below procedure computes the k-factors from the xross-sections specified in xsecs_nlo above
     # this proceudre is used only for Run-2 (13 TeV)
     # for Run-3 (13.6 TeV) we do the kfactor scaling in the cross sections file so this is not needed
-    xsec_incl_corrected = xsec_incl or getxsec_nlo(name,*searchterms) or xsec_incl
-    kfactor       = xsec_incl_corrected / xsec_incl
+    xsec_incl_corrected = xsec_incl or getxsec_nlo(name,*searchterms) or xsec_incl_initial
+    kfactor       = xsec_incl_corrected / xsec_incl_initial
   else:
     # if no kfactor is specified and we are not doing Run-2 (cme=13) method then we set kfactor to 1
     # in the Run-3 method the kfactor is applied to the inputted cross-sections, so by setting this to 1 we ensure it does not get applied twice 
-    xsec_incl_corrected = xsec_incl
+    xsec_incl_corrected = xsec_incl_initial
     kfactor=1. 
-  LOG.verb("  %s k-factor = %.2f = %.2f / %.2f"%(name,kfactor,xsec_incl_corrected,xsec_incl),verbosity,level=2)
+  LOG.verb("  %s k-factor = %.2f = %.2f / %.2f"%(name,kfactor,xsec_incl_corrected,xsec_incl_initial),verbosity,level=2)
 
   if len(stitchlist)<2:
     LOG.warn("stitch: Could not stitch %r: fewer than two %s samples (%d) match '%s'-- still applying k-factor to inclusive sample"%(


### PR DESCRIPTION
- Adding cross sections for Run-3
- Samples that are not currently available are commented out
- For Run-3 we will do the kfactor scaling inside the cross sections file
- The kfactor scaling is thus removed in the stitching. It needs to be check that this works properly and also does not break anything when processing Run-2
- The dataset names are also updated but need to modify the code to account for 2022_preEE havign 2 dataset names: SingleMuonC, MuonC, and MuonD