### PR TITLE
Add default batch options to configuration

### DIFF
--- a/PicoProducer/python/tools/config.py
+++ b/PicoProducer/python/tools/config.py
@@ -49,7 +49,8 @@ def getdefaultconfig(verb=0):
     nanodir       = sedir+"samples/nano/$ERA/$DAS"   # for storage of (skimmed) nanoAOD
     filelistdir   = "samples/files/$ERA/$SAMPLE.txt" # location to save list of files
     batchsystem   = guess_batch()                    # batch system (HTCondor, SLURM, ...)
-    queue         = ""                               # batch queue / job flavor
+    batchqueue    = ""                               # batch queue / job flavor
+    batchopts     = ""                               # extra batch options
     nfilesperjob  = 1                                # group files per job
     maxevtsperjob = -1                               # maximum number of events per job (split large files)
     maxopenfiles  = 500                              # maximum number of open files during hadd
@@ -60,7 +61,7 @@ def getdefaultconfig(verb=0):
       #('basedir',basedir), # import instead
       ('jobdir',jobdir),     ('outdir',outdir), ('nanodir',nanodir), ('picodir',picodir),
       ('tmpskimdir',tmpskimdir),
-      ('batch',batchsystem), ('queue',queue),
+      ('batch',batchsystem), ('queue',batchqueue), ('batchopts',batchopts),
       ('nfilesperjob',nfilesperjob), ('maxevtsperjob',maxevtsperjob),
       ('filelistdir',filelistdir),
       ('maxopenfiles',maxopenfiles), ('haddcmd', haddcmd ), # for pico.py hadd

--- a/PicoProducer/scripts/pico.py
+++ b/PicoProducer/scripts/pico.py
@@ -88,8 +88,8 @@ if __name__ == "__main__":
                                                 help="preselection to be shipped to skimjob.py during run command")
   parser_job.add_argument('-p','--prefetch',    dest='prefetch', action='store_true',
                                                 help="copy remote file during job to increase processing speed and ensure stability")
-  parser_job.add_argument('-B','--batch-opts',  dest='batchopts', default=None,
-                                                help="extra options for the batch system")
+  parser_job.add_argument('-B','--batch-opts',  dest='batchopts', default=CONFIG.batchopts,
+                                                help="extra options for the batch system, default=%(default)r")
   parser_job.add_argument('-M','--time',        dest='time', default=None,
                                                 help="maximum run time of job")
   parser_job.add_argument('-q','--queue',       dest='queue', default=str(CONFIG.queue),


### PR DESCRIPTION
To add extra options to the batch system, one can do something like
```
pico.py submit ... -B '\-spool'
```
Since this is a bit cumbersome and ugly, this PR adds a way to set the extra batch options as default
```
pico.py set batchopts '\-spool'
pico.py submit ... # condor_submit should now include the -spool option
```