### PR TITLE
Implement correctionlib JSONs for muon SFs

### DIFF
--- a/PicoProducer/python/analysis/ModuleMuMu.py
+++ b/PicoProducer/python/analysis/ModuleMuMu.py
@@ -22,19 +22,19 @@ class ModuleMuMu(ModuleTauPair):
     if self.year==2016:
       #self.trigger    = lambda e: e.HLT_IsoMu22 or e.HLT_IsoMu22_eta2p1 or e.HLT_IsoTkMu22 or e.HLT_IsoTkMu22_eta2p1 #or e.HLT_IsoMu19_eta2p1_LooseIsoPFTau20_SingleL1
       #self.trigger    = lambda e: e.HLT_IsoMu24 or e.HLT_IsoTkMu24
-      self.muon1CutPt = lambda e: 25
+      self.muon1CutPt = lambda e: 26
       self.muonCutEta = lambda e: 2.4 #if e.HLT_IsoMu22 or e.HLT_IsoTkMu22 else 2.1
     elif self.year==2017:
       #self.trigger    = lambda e: e.HLT_IsoMu24 or e.HLT_IsoMu27 #or e.HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1
-      self.muon1CutPt = lambda e: 25 if e.HLT_IsoMu24 else 29
+      self.muon1CutPt = lambda e: 26 if e.HLT_IsoMu24 else 29
       self.muonCutEta = lambda e: 2.4
     elif self.year==2022:
       #self.trigger    = lambda e: e.HLT_IsoMu24 or e.HLT_IsoMu27#e.HLT_IsoMu27 #or e.HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1
-      self.muon1CutPt  = lambda e: 25
+      self.muon1CutPt  = lambda e: 26
       self.muonCutEta = lambda e: 2.4
     else:
       #self.trigger    = lambda e: e.HLT_IsoMu24 or e.HLT_IsoMu27 #or e.HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1
-      self.muon1CutPt = lambda e: 25
+      self.muon1CutPt = lambda e: 26
       self.muonCutEta = lambda e: 2.4
     self.muon2CutPt   = 15
     self.tauCutPt     = 20

--- a/PicoProducer/python/corrections/BTagTool.py
+++ b/PicoProducer/python/corrections/BTagTool.py
@@ -101,7 +101,7 @@ class BTagWPs:
 
 class BTagWeightTool:
   
-  def __init__(self,tagger,wp,era,channel,maxeta=None,loadsys=False,type_bc='comb',spliteras=False,filltags=[""]):
+  def __init__(self,tagger,wp,era,channel='all',maxeta=None,loadsys=False,type_bc='comb',spliteras=False,filltags=[""]):
     """Load b tag weights from CSV file."""
     
     #assert(year in [2016,2017,2018]), "You must choose a year from: 2016, 2017, or 2018."
@@ -142,9 +142,7 @@ class BTagWeightTool:
       if 'UL' not in effname:
         LOG.warning("Using pre-UL place holder %r for efficiencies! Please update."%(effname))
     else: # pre-UL
-      if '2022' in era or '2023' in era:
-        # https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL18
-        # https://github.com/scodella/ScaleFactorCombinationTools/tree/master/CSVFiles
+      if '2022' in era or '2023' in era: # PLACEHOLDERS
         if 'deepjet' in tagger.lower(): # DeepFlavour b+bb+lepb
           #csvname    = datadir+"DeepJet_106XUL18SF.csv"
           csvname    = datadir+"wp_deepJet_106XUL18_v2_reformatted.csv" # TODO: update BTagCalibration to read correct file !!!

--- a/PicoProducer/python/corrections/MuonSFs.py
+++ b/PicoProducer/python/corrections/MuonSFs.py
@@ -98,10 +98,10 @@ class MuonSFs:
       else:
         print("Loading MuonSF for era=%r, id=%r, iso=%r, trig=%r from %s..."%(era,sf_id,sf_id,sf_trig,fname_id))
     if not os.path.exists(fname_id):
-      LOG.throw(OSError,"MuonSFs: fname_id={fname_id} does not exist! Please make sure you have installed the correctionlib JSON data in %s"
+      LOG.throw(OSError,"MuonSFs: fname_id=%s does not exist! Please make sure you have installed the correctionlib JSON data in %s"
                         " following the instructions in https://github.com/cms-tau-pog/TauFW/wiki/Installation#Corrections !"%(fname_id,datadir))
     if fname_trig and not os.path.exists(fname_trig):
-      LOG.throw(OSError,"MuonSFs: fname_trig={fname_trig} does not exist! Please make sure you have installed the HTT lepton ROOT data in %s"
+      LOG.throw(OSError,"MuonSFs: fname_trig=%s does not exist! Please make sure you have installed the HTT lepton ROOT data in %s"
                         " following the instructions in https://github.com/cms-tau-pog/TauFW/wiki/Installation#Corrections !"%(fname_id,datadir))
     
     # LOAD CORRECTIONS

--- a/PicoProducer/python/corrections/MuonSFs.py
+++ b/PicoProducer/python/corrections/MuonSFs.py
@@ -72,9 +72,9 @@ class MuonSFs:
     else: # Run-3
       # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonRun32022
       # https://twiki.cern.ch/twiki/bin/view/CMS/MuonRun3_2023
-      if re.search(r"2022([C-D]|.*pre)",era): # 2022C-D (preEE)
+      if re.search(r"2022([C-D]|.*pre)",era): # 2022CD (preEE)
         fname_id = pathPOG+"2022_Summer22/muon_Z.json.gz"
-      elif re.search(r"2022([E-G]|.*post)",era): # 2022C-D (postEE)
+      elif re.search(r"2022([E-G]|.*post)",era): # 2022EFG (postEE)
         fname_id = pathPOG+"2022_Summer22EE/muon_Z.json.gz"
       elif re.search(r"2023(C|.*pre)",era): # 2024C (preBPIX)
         fname_id = pathPOG+"2023_Summer23/muon_Z.json.gz"

--- a/PicoProducer/python/corrections/MuonSFs.py
+++ b/PicoProducer/python/corrections/MuonSFs.py
@@ -98,7 +98,10 @@ class MuonSFs:
       else:
         print("Loading MuonSF for era=%r, id=%r, iso=%r, trig=%r from %s..."%(era,sf_id,sf_id,sf_trig,fname_id))
     if not os.path.exists(fname_id):
-      LOG.throw(OSError,"MuonSFs: fname={fname_id} does not exist! Please make sure you have installed the correctionlib JSON data in %s"
+      LOG.throw(OSError,"MuonSFs: fname_id={fname_id} does not exist! Please make sure you have installed the correctionlib JSON data in %s"
+                        " following the instructions in https://github.com/cms-tau-pog/TauFW/wiki/Installation#Corrections !"%(fname_id,datadir))
+    if fname_trig and not os.path.exists(fname_trig):
+      LOG.throw(OSError,"MuonSFs: fname_trig={fname_trig} does not exist! Please make sure you have installed the HTT lepton ROOT data in %s"
                         " following the instructions in https://github.com/cms-tau-pog/TauFW/wiki/Installation#Corrections !"%(fname_id,datadir))
     
     # LOAD CORRECTIONS

--- a/PicoProducer/python/corrections/MuonSFs.py
+++ b/PicoProducer/python/corrections/MuonSFs.py
@@ -3,105 +3,140 @@
 # MuonPOG: https://gitlab.cern.ch/cms-muonPOG/muonefficiencies/-/tree/master/Run2
 # https://twiki.cern.ch/twiki/bin/view/CMS/MuonPOG#User_Recommendations
 # https://twiki.cern.ch/twiki/bin/view/CMS/MuonLegacy2016
-import os
+# correctionlib:
+#   https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration     # central XPOG repo
+#   https://gitlab.cern.ch/cms-muonPOG/muonefficiencies        # early MuonPOG releases
+#   https://cms-nanoaod-integration.web.cern.ch/commonJSONSFs/ # JSON contents
+#   correction summary data/jsonpog/POG/MUO/*/muon_Z.json.gz   # JSON contents
+#   zgrep abseta data/jsonpog/POG/MUO/*/muon_Z.json.gz         # JSON contents (check for abseta)
+#   https://github.com/cms-cat/nanoAOD-tools-modules/blob/master/python/modules/muonSF.py
+#   https://github.com/cms-cat/nanoAOD-tools-modules/blob/master/test/example_muonSF.py
+import os, re
+from TauFW.common.tools.log import Logger
 from TauFW.PicoProducer import datadir
-from TauFW.PicoProducer.corrections.ScaleFactorTool import ScaleFactor, ScaleFactorHTT 
-pathPOG = os.path.join(datadir,"lepton/MuonPOG/")
-pathHTT = os.path.join(datadir,"lepton/HTT/Muon/")
+from TauFW.PicoProducer.corrections.ScaleFactorTool import ScaleFactorHTT
+from correctionlib import CorrectionSet
+#pathPOG = os.path.join(datadir,"lepton/MuonPOG/") # ROOT files from MUO
+pathHTT = os.path.join(datadir,"lepton/HTT/Muon/") # ROOT files from HTT
+pathPOG = os.path.join(datadir,"jsonpog/POG/MUO/") # JSON files from central XPOG
+pathMUO = os.path.join(datadir,"lepton/MuonPOG/json/") # JSON files from central XPOG
+LOG = Logger('MuonSF')
 
+
+def getcorr(corrset,sfname,abseta=False,verb=0):
+  """Help function to extract Correction object and
+  check if Correction inputs are what we expect them to be."""
+  keys = list(corrset.keys())
+  LOG.insist(sfname in corrset, "Did not find key %r in correctionset! Available keys: %r"%(sfname,keys))
+  corr   = corrset[sfname]
+  inputs = [i.name for i in corr._base.inputs]
+  eta    = 'eta' #'abseta' if abseta else 'eta' # MuonPOG now consistently uses transform for eta -> abs(eta)
+  LOG.insist(len(inputs)==3,    "Expected len(inputs)==3, but got %s... Inputs: %s"%(len(inputs),inputs))
+  LOG.insist(eta in inputs[0],  "Expected %s as first input, but got %s! All inputs for %s: %s"%(eta,inputs[0],sfname,inputs))
+  LOG.insist('pt' in inputs[1], "Expected pt as second input, but got %s! All inputs for %s: %s"%(inputs[1],sfname,inputs))
+  return corr
+  
 
 class MuonSFs:
   
-  def __init__(self, era='2017', flags=[ ], verb=0):
-    """Load histograms from files."""
+  def __init__(self, era, sf_id="NUM_MediumID_DEN_TrackerMuons", sf_iso="NUM_TightRelIso_DEN_MediumID", flags=[ ], verb=0):
+    """Prepare muon SFs from JSON files."""
     
-    #eras = ['2016','2017','2018','UL2017']
-    #assert era in eras, "MuonSFs: You must choose a year from: %s."%(', '.join(eras))
-    self.sftool_trig = None
-    self.sftool_idiso = None
+    # SETTINGS
+    fname       = None
+    fname_trig  = None
+    #abseta      = True # use absolute eta (default in Run 2, 2022)
+    sf_trig     = "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight" # default used in 2018 + Run 3
     if 'UL' in era:
+      # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
+      # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017
+      # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017
       if '2016' in era and 'preVFP' in era:
-        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
-        self.sftool_trig  = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_SingleMuonTriggers.root",
-                                           'NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
-        sftool_id         = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
-        sftool_iso        = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
-        self.sftool_idiso = sftool_id*sftool_iso
+        sf_trig = "NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+        fname   = pathPOG+"2016preVFP_UL/muon_Z.json.gz"
       elif '2016' in era:
-        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
-        self.sftool_trig  = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_SingleMuonTriggers.root",
-                                           'NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
-        sftool_id         = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
-        sftool_iso        = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
-        self.sftool_idiso = sftool_id*sftool_iso
+        sf_trig = "NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+        fname   = pathPOG+"2016postVFP_UL/muon_Z.json.gz"
       elif '2017' in era:
-        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017
+        fname   = pathPOG+"2018_UL/muon_Z.json.gz"
         if 'HLT_IsoMu27' in flags: # use only HLT_IsoMu27
-          self.sftool_trig = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_SingleMuonTriggers.root",
-                                             'NUM_IsoMu27_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
-        else: # use HLT_IsoMu24 || HLT_IsoMu27
-          self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root",'ZMass','mu_trig',verb=verb) # placeholder
-        sftool_id         = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
-        sftool_iso        = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
-        self.sftool_idiso = sftool_id*sftool_iso
+          sf_trig = "NUM_IsoMu27_DEN_CutBasedIdTight_and_PFIsoTight"
+        else: # default: use (HLT_IsoMu24 || HLT_IsoMu27)
+          sf_trig = "mu_trig"
+          fname_trig = pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root"
       elif '2018' in era:
-        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017
-        ###self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2018/Muon_Run2018_IsoMu24orIsoMu27.root",'ZMass','mu_trig',verb=verb) # placeholder
-        self.sftool_trig  = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_SingleMuonTriggers.root",
-                                           'NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
-        sftool_id         = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
-        sftool_iso        = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
-        self.sftool_idiso = sftool_id*sftool_iso
-    else: # pre-UL or Run3
-      if era=='2016':
-        # https://gitlab.cern.ch/cms-muonPOG/MuonReferenceEfficiencies/-/tree/master/EfficienciesStudies/2016_trigger
-        #self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IsoMu22.root",'ZMass','mu_trig',verb=verb)
-        self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IsoMu24.root",'ZMass','mu_trig',verb=verb)
-        self.sftool_idiso = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IdIso.root",'ZMass','mu_idiso',verb=verb)
-        ###self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root",'ZMass','mu_idiso',verb=verb) # placeholder
-        ###sftool_id         = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
-        ###sftool_iso        = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=False,verb=verb)
-        ###self.sftool_idiso = sftool_id*sftool_iso
-      elif era=='2017':
-        #self.sftool_trig  = ScaleFactor(pathPOG+"Run2017/EfficienciesAndSF_RunBtoF_Nov17Nov2017.root","IsoMu27_PtEtaBins/abseta_pt_ratio",'mu_trig')
-        self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root",'ZMass','mu_idiso',verb=verb)
-        self.sftool_idiso = ScaleFactorHTT(pathHTT+"Run2017/Muon_IdIso_IsoLt0.15_eff_RerecoFall17.root",'ZMass','mu_idiso',verb=verb)
-        ###sftool_id         = ScaleFactor(pathPOG+"Run2017/RunBCDEF_SF_ID.root","NUM_MediumID_DEN_genTracks_pt_abseta",'mu_id',ptvseta=False)
-        ###sftool_iso        = ScaleFactor(pathPOG+"Run2017/RunBCDEF_SF_ISO.root","NUM_TightRelIso_DEN_MediumID_pt_abseta",'mu_iso',ptvseta=False)
-        ###self.sftool_idiso = sftool_id*sftool_iso
-      elif era=='2018':
-        self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2018/Muon_Run2018_IsoMu24orIsoMu27.root",'ZMass','mu_trig',verb=verb)
-        self.sftool_idiso = ScaleFactorHTT(pathHTT+"Run2018/Muon_Run2018_IdIso.root") # MediumID, DB corrected iso (dR<0.4) < 0.15
-        ###sftool_id         = ScaleFactor(pathPOG+"Run2018/RunABCD_SF_ID.root","NUM_MediumID_DEN_genTracks_pt_abseta",'mu_id',ptvseta=False)
-        ###sftool_iso        = ScaleFactor(pathPOG+"Run2018/RunABCD_SF_ISO.root","NUM_TightRelIso_DEN_MediumID_pt_abseta",'mu_iso',ptvseta=False)
-        ###self.sftool_idiso = sftool_id*sftool_iso
-      elif '2022' in era and 'pre' in era:
-        self.sftool_trig  = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
-        self.sftool_id         = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
-        self.sftool_iso        = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)
-        assert self.sftool_id != None and self.sftool_iso != None, "MuonSFs.__init__: Did not find muon ID/ISO tool for %r"%(era)
-        self.sftool_idiso = self.sftool_id*self.sftool_iso
-      elif '2022' in era and 'post' in era:
-        self.sftool_trig  = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
-        self.sftool_id         = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
-        self.sftool_iso        = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)
-        assert self.sftool_id != None and self.sftool_iso != None, "MuonSFs.__init__: Did not find muon ID/ISO tool for %r"%(era)
-        self.sftool_idiso = self.sftool_id*self.sftool_iso
-      elif '2023' in era: # PLACEHOLDERS
-        print(">>> WARNING! MuonSFs.__init__ using Run2022 SFs as placeholders! Please replace me! https://twiki.cern.ch/twiki/bin/view/CMS/MuonRun3_2023")
-        self.sftool_trig  = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
-        self.sftool_id         = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
-        self.sftool_iso        = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)
-        assert self.sftool_id != None and self.sftool_iso != None, "MuonSFs.__init__: Did not find muon ID/ISO tool for %r"%(era)
-        self.sftool_idiso = self.sftool_id*self.sftool_iso
-    assert self.sftool_trig!=None and self.sftool_idiso!=None, "MuonSFs.__init__: Did not find muon SF tool for %r"%(era)
-    print("Loading MuonSF for %s, %s"%(self.sftool_trig.filename,self.sftool_idiso.filename))
+        fname = pathPOG+"2018_UL/muon_Z.json.gz"
+    else: # Run-3
+      # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonRun32022
+      # https://twiki.cern.ch/twiki/bin/view/CMS/MuonRun3_2023
+      if re.search(r"2022([C-D]|.*pre)",era): # 2022C-D (preEE)
+        fname = pathPOG+"2022_Summer22/muon_Z.json.gz"
+      elif re.search(r"2022([E-G]|.*post)",era): # 2022C-D (postEE)
+        fname = pathPOG+"2022_Summer22EE/muon_Z.json.gz"
+      elif re.search(r"2023(C|.*pre)",era): # 2024C (preBPIX)
+        fname = pathPOG+"2023_Summer23/muon_Z.json.gz"
+        #abseta = False
+      elif re.search(r"2023(D|.*post)",era): # 2024D (postBPIX)
+        fname = pathPOG+"2023_Summer23BPix/muon_Z.json.gz"
+        #abseta = False
+    
+    # LOAD
+    if verb>=0:
+      if fname_trig: # special exception: (HLT_IsoMu24 || HLT_IsoMu27)
+        print("Loading MuonSF for era=%r, id=%r, iso=%r from %s..."%(era,sf_id,sf_id,sf_trig,fname))
+      else:
+        print("Loading MuonSF for era=%r, id=%r, iso=%r, trig=%r from %s..."%(era,sf_id,sf_id,sf_trig,fname))
+    if not os.path.exists(fname):
+      LOG.throw(OSError,"MuonSFs: fname={fname} does not exist! Please make sure you have installed the correctionlib JSON data in %s"
+                        " following the instructions in https://github.com/cms-tau-pog/TauFW/wiki/Installation#Corrections !"%(fname,datadir))
+    corrset = CorrectionSet.from_file(fname) # load JSON
+    self.sftool_id  = getcorr(corrset,sf_id, verb=verb)
+    self.sftool_iso = getcorr(corrset,sf_iso,verb=verb)
+    if fname_trig: # special exception: load ROOT file for (HLT_IsoMu24 || HLT_IsoMu27)
+      print("Loading MuonSF for era=%r, trig=%r from %s..."%(era,sf_trig,fname_trig))
+      self.sftool_trig = ScaleFactorHTT(fname_trig,'ZMass',sf_trig,verb=verb) # HTT ROOT
+    else: # load correctionlib JSON: HLT_IsoMu24, HLT_IsoMu27, etc.
+      self.sftool_trig = corrset[sf_trig] # correctionlib JSON
+    
   
-  def getTriggerSF(self, pt, eta):
-    """Get SF for single muon trigger."""
-    return self.sftool_trig.getSF(pt,abs(eta))
+  def getTriggerSF(self, pt, eta, syst=None):
+    """Get SF for single muon trigger.
+    Use syst='systup', 'systdown' for systematic variations."""
+    ###if self.abseta: # MuonPOG now consistently uses transform for eta -> abs(eta)
+    ###  eta = abs(eta)
+    try:
+      sf = self.sftool_trig.evaluate(eta,pt,'nominal')
+      if syst: # systematic variations: 'syst', 'stat', ...
+        unc = self.sftool_id.evaluate(eta,pt,syst)
+        sf = (sf,sf+unc,sf-unc)
+    except Exception as error:
+      LOG.throw(error,"MuonSF.getTriggerSF: Caught %r for (pt,eta,syst)=(%s,%s,%s)!"%(str(error),pt,eta,syst)+
+                "Please review MuonPOG's recommendations and check your cuts...")
+    return sf
+    
   
-  def getIdIsoSF(self, pt, eta):
+  def getIdIsoSF(self, pt, eta, syst='nominal'):
     """Get SF for muon identification + isolation."""
-    return self.sftool_idiso.getSF(pt,abs(eta))
+    ###if self.abseta: # MuonPOG now consistently uses transform for eta -> abs(eta)
+    ###  eta = abs(eta)
+    return self.sftool_id.evaluate(eta,pt,syst)*self.sftool_iso.evaluate(eta,pt,syst)
+    
+  
+  def getIdSF(self, pt, eta, syst=None):
+    """Get SF for muon identification."""
+    sf = self.sftool_id.evaluate(eta,pt,'nominal')
+    if syst: # systematic variations: syst = 'syst', 'stat', ...
+      unc = self.sftool_id.evaluate(eta,pt,syst)
+      return (sf,sf+unc,sf-unc) # (nominal, up, down)
+    return sf # nominal
+    
+  
+  def getIsoSF(self, pt, eta, syst=None):
+    """Get SF for muon isolation."""
+    sf = self.sftool_iso.evaluate(eta,pt,'nominal')
+    if syst: # systematic variations: syst = 'syst', 'stat', ...
+      unc = self.sftool_iso.evaluate(eta,pt,syst)
+      return (sf,sf+unc,sf-unc) # (nominal, up, down)
+    return sf # nominal
+    
   

--- a/PicoProducer/python/corrections/MuonSFs_ROOT.py
+++ b/PicoProducer/python/corrections/MuonSFs_ROOT.py
@@ -1,0 +1,100 @@
+# Author: Izaak Neutelings (December 2018)
+# HTT: https://github.com/CMS-HTT/LeptonEfficiencies
+# MuonPOG: https://gitlab.cern.ch/cms-muonPOG/muonefficiencies/-/tree/master/Run2
+# https://twiki.cern.ch/twiki/bin/view/CMS/MuonPOG#User_Recommendations
+# https://twiki.cern.ch/twiki/bin/view/CMS/MuonLegacy2016
+import os
+from TauFW.PicoProducer import datadir
+from TauFW.PicoProducer.corrections.ScaleFactorTool import ScaleFactor, ScaleFactorHTT 
+pathPOG = os.path.join(datadir,"lepton/MuonPOG/")
+pathHTT = os.path.join(datadir,"lepton/HTT/Muon/")
+
+
+class MuonSFs:
+  
+  def __init__(self, era='2017', flags=[ ], verb=0):
+    """Load histograms from files."""
+    
+    #eras = ['2016','2017','2018','UL2017']
+    #assert era in eras, "MuonSFs: You must choose a year from: %s."%(', '.join(eras))
+    self.sftool_trig = None
+    self.sftool_idiso = None
+    if 'UL' in era:
+      if '2016' in era and 'preVFP' in era:
+        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
+        self.sftool_trig  = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_SingleMuonTriggers.root",
+                                           'NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
+        sftool_id         = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
+        sftool_iso        = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
+        self.sftool_idiso = sftool_id*sftool_iso
+      elif '2016' in era:
+        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
+        self.sftool_trig  = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_SingleMuonTriggers.root",
+                                           'NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
+        sftool_id         = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
+        sftool_iso        = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
+        self.sftool_idiso = sftool_id*sftool_iso
+      elif '2017' in era:
+        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017
+        if 'HLT_IsoMu27' in flags: # use only HLT_IsoMu27
+          self.sftool_trig = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_SingleMuonTriggers.root",
+                                             'NUM_IsoMu27_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
+        else: # use HLT_IsoMu24 || HLT_IsoMu27
+          self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root",'ZMass','mu_trig',verb=verb) # placeholder
+        sftool_id         = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
+        sftool_iso        = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
+        self.sftool_idiso = sftool_id*sftool_iso
+      elif '2018' in era:
+        # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017
+        ###self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2018/Muon_Run2018_IsoMu24orIsoMu27.root",'ZMass','mu_trig',verb=verb) # placeholder
+        self.sftool_trig  = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_SingleMuonTriggers.root",
+                                           'NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
+        sftool_id         = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
+        sftool_iso        = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
+        self.sftool_idiso = sftool_id*sftool_iso
+    else: # pre-UL
+      if era=='2016':
+        # https://gitlab.cern.ch/cms-muonPOG/MuonReferenceEfficiencies/-/tree/master/EfficienciesStudies/2016_trigger
+        #self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IsoMu22.root",'ZMass','mu_trig',verb=verb)
+        self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IsoMu24.root",'ZMass','mu_trig',verb=verb)
+        self.sftool_idiso = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IdIso.root",'ZMass','mu_idiso',verb=verb)
+        ###self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root",'ZMass','mu_idiso',verb=verb) # placeholder
+        ###sftool_id         = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
+        ###sftool_iso        = ScaleFactor(pathPOG+"Run2017UL/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=False,verb=verb)
+        ###self.sftool_idiso = sftool_id*sftool_iso
+      elif era=='2017':
+        #self.sftool_trig  = ScaleFactor(pathPOG+"Run2017/EfficienciesAndSF_RunBtoF_Nov17Nov2017.root","IsoMu27_PtEtaBins/abseta_pt_ratio",'mu_trig')
+        self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2017/Muon_IsoMu24orIsoMu27.root",'ZMass','mu_idiso',verb=verb)
+        self.sftool_idiso = ScaleFactorHTT(pathHTT+"Run2017/Muon_IdIso_IsoLt0.15_eff_RerecoFall17.root",'ZMass','mu_idiso',verb=verb)
+        ###sftool_id         = ScaleFactor(pathPOG+"Run2017/RunBCDEF_SF_ID.root","NUM_MediumID_DEN_genTracks_pt_abseta",'mu_id',ptvseta=False)
+        ###sftool_iso        = ScaleFactor(pathPOG+"Run2017/RunBCDEF_SF_ISO.root","NUM_TightRelIso_DEN_MediumID_pt_abseta",'mu_iso',ptvseta=False)
+        ###self.sftool_idiso = sftool_id*sftool_iso
+      elif era=='2018':
+        self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2018/Muon_Run2018_IsoMu24orIsoMu27.root",'ZMass','mu_trig',verb=verb)
+        self.sftool_idiso = ScaleFactorHTT(pathHTT+"Run2018/Muon_Run2018_IdIso.root") # MediumID, DB corrected iso (dR<0.4) < 0.15
+        ###sftool_id         = ScaleFactor(pathPOG+"Run2018/RunABCD_SF_ID.root","NUM_MediumID_DEN_genTracks_pt_abseta",'mu_id',ptvseta=False)
+        ###sftool_iso        = ScaleFactor(pathPOG+"Run2018/RunABCD_SF_ISO.root","NUM_TightRelIso_DEN_MediumID_pt_abseta",'mu_iso',ptvseta=False)
+        ###self.sftool_idiso = sftool_id*sftool_iso
+      elif '2022_preEE' in era:
+        self.sftool_trig  = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
+        self.sftool_id         = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
+        self.sftool_iso        = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)
+        assert self.sftool_id != None and self.sftool_iso != None, "MuonSFs.__init__: Did not find muon ID/ISO tool for %r"%(era)
+        self.sftool_idiso = self.sftool_id*self.sftool_iso
+      elif '2022_postEE' in era:
+        self.sftool_trig  = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
+        self.sftool_id         = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
+        self.sftool_iso        = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)
+        assert self.sftool_id != None and self.sftool_iso != None, "MuonSFs.__init__: Did not find muon ID/ISO tool for %r"%(era)
+        self.sftool_idiso = self.sftool_id*self.sftool_iso
+    assert self.sftool_trig!=None and self.sftool_idiso!=None, "MuonSFs.__init__: Did not find muon SF tool for %r"%(era)
+    print("Loading MuonSF for %s, %s"%(self.sftool_trig.filename,self.sftool_idiso.filename))
+  
+  def getTriggerSF(self, pt, eta):
+    """Get SF for single muon trigger."""
+    return self.sftool_trig.getSF(pt,abs(eta))
+  
+  def getIdIsoSF(self, pt, eta):
+    """Get SF for muon identification + isolation."""
+    return self.sftool_idiso.getSF(pt,abs(eta))
+  

--- a/PicoProducer/python/corrections/MuonSFs_ROOT.py
+++ b/PicoProducer/python/corrections/MuonSFs_ROOT.py
@@ -3,7 +3,7 @@
 # MuonPOG: https://gitlab.cern.ch/cms-muonPOG/muonefficiencies/-/tree/master/Run2
 # https://twiki.cern.ch/twiki/bin/view/CMS/MuonPOG#User_Recommendations
 # https://twiki.cern.ch/twiki/bin/view/CMS/MuonLegacy2016
-import os
+import os, re
 from TauFW.PicoProducer import datadir
 from TauFW.PicoProducer.corrections.ScaleFactorTool import ScaleFactor, ScaleFactorHTT 
 pathPOG = os.path.join(datadir,"lepton/MuonPOG/")
@@ -20,14 +20,14 @@ class MuonSFs:
     self.sftool_trig = None
     self.sftool_idiso = None
     if 'UL' in era:
-      if '2016' in era and 'preVFP' in era:
+      if '2016' in era and 'pre' in era:
         # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
         self.sftool_trig  = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_SingleMuonTriggers.root",
                                            'NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
         sftool_id         = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
         sftool_iso        = ScaleFactor(pathPOG+"Run2016UL_preVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
         self.sftool_idiso = sftool_id*sftool_iso
-      elif '2016' in era:
+      elif '2016' in era: # assume post-VFP
         # https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016
         self.sftool_trig  = ScaleFactor(pathPOG+"Run2016UL_postVFP/Efficiencies_muon_generalTracks_Z_Run2016_UL_SingleMuonTriggers.root",
                                            'NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_eta_pt','mu_trig',verb=verb)
@@ -52,7 +52,7 @@ class MuonSFs:
         sftool_id         = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.root","NUM_MediumID_DEN_TrackerMuons_abseta_pt",'mu_id',ptvseta=True,verb=verb)
         sftool_iso        = ScaleFactor(pathPOG+"Run2018UL/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root","NUM_TightRelIso_DEN_MediumID_abseta_pt",'mu_iso',ptvseta=True,verb=verb)
         self.sftool_idiso = sftool_id*sftool_iso
-    else: # pre-UL
+    elif '201' in era: # pre-UL Run 2
       if era=='2016':
         # https://gitlab.cern.ch/cms-muonPOG/MuonReferenceEfficiencies/-/tree/master/EfficienciesStudies/2016_trigger
         #self.sftool_trig  = ScaleFactorHTT(pathHTT+"Run2016_legacy/Muon_Run2016_legacy_IsoMu22.root",'ZMass','mu_trig',verb=verb)
@@ -75,13 +75,14 @@ class MuonSFs:
         ###sftool_id         = ScaleFactor(pathPOG+"Run2018/RunABCD_SF_ID.root","NUM_MediumID_DEN_genTracks_pt_abseta",'mu_id',ptvseta=False)
         ###sftool_iso        = ScaleFactor(pathPOG+"Run2018/RunABCD_SF_ISO.root","NUM_TightRelIso_DEN_MediumID_pt_abseta",'mu_iso',ptvseta=False)
         ###self.sftool_idiso = sftool_id*sftool_iso
-      elif '2022_preEE' in era:
+    else: # EOY Run 3
+      if re.search(r"2022([C-D]|.*pre)",era): # 2022CD (preEE)
         self.sftool_trig  = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
         self.sftool_id         = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
         self.sftool_iso        = ScaleFactor(pathPOG+"Run2022preEE/muon_SFs_2022_preEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)
         assert self.sftool_id != None and self.sftool_iso != None, "MuonSFs.__init__: Did not find muon ID/ISO tool for %r"%(era)
         self.sftool_idiso = self.sftool_id*self.sftool_iso
-      elif '2022_postEE' in era:
+      elif re.search(r"2022([E-G]|.*post)",era): # 2022EFG (postEE)
         self.sftool_trig  = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root",'ScaleFactor_trg','mu_trig',ptvseta=False,verb=verb)
         self.sftool_id         = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_id",'mu_id',ptvseta=False)
         self.sftool_iso        = ScaleFactor(pathPOG+"Run2022postEE/muon_SFs_2022_postEE.root","ScaleFactor_iso",'mu_iso',ptvseta=False)

--- a/PicoProducer/python/corrections/ScaleFactorTool.py
+++ b/PicoProducer/python/corrections/ScaleFactorTool.py
@@ -78,7 +78,7 @@ class ScaleFactorHTT(ScaleFactor):
         LOG.throw(IOError,"%s You may have to do\n"%(strerr)+
           "        cd $CMSSW_BASE/src/TauFW/PicoProducer/data/lepton/\n"+
           "        rm -rf HTT\n"+
-          "        git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT"+
+          "        git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT\n"+
           "      Please see https://github.com/cms-tau-pog/TauFW/wiki/Installation#corrections")
       else:
         raise error

--- a/PicoProducer/python/corrections/ScaleFactorTool.py
+++ b/PicoProducer/python/corrections/ScaleFactorTool.py
@@ -76,9 +76,10 @@ class ScaleFactorHTT(ScaleFactor):
       strerr = str(error).replace('\033[0m','')
       if '/HTT/' in filename and "does not exist" in strerr:
         LOG.throw(IOError,"%s You may have to do\n"%(strerr)+
-          "  cd $CMSSW_BASE/src/TauFW/PicoProducer/data/lepton/\n"+
-          "  rm -rf HTT\n"+
-          "  git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT")
+          "        cd $CMSSW_BASE/src/TauFW/PicoProducer/data/lepton/\n"+
+          "        rm -rf HTT\n"+
+          "        git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT"+
+          "      Please see https://github.com/cms-tau-pog/TauFW/wiki/Installation#corrections")
       else:
         raise error
     self.hist_eta  = self.file.Get('etaBinsH')
@@ -90,6 +91,10 @@ class ScaleFactorHTT(ScaleFactor):
       self.effs_data[etalabel] = self.file.Get(graphname+etalabel+"_Data")
       self.effs_mc[etalabel]   = self.file.Get(graphname+etalabel+"_MC")
     self.file.Close()
+  
+  def evaluate(self, eta, pt, sf='sf'):
+    """For compatibility with correctionlib's Correction.evaluate for MUO POG."""
+    return self.getSF(pt,eta)
   
   def getSF(self, pt, eta):
     """Get SF for a given pT, eta."""

--- a/PicoProducer/test/testSFs.py
+++ b/PicoProducer/test/testSFs.py
@@ -2,116 +2,103 @@
 # Author: Izaak Neutelings (December 2018)
 import time
 start0 = time.time()
-print('')
-print(">>> importing modules...")
-from TauFW.common.tools.log import Logger
+print(">>> Importing modules...")
+from TauFW.common.tools.log import Logger, color, underline
 LOG = Logger("testSF")
-
-start1 = time.time()
-from ROOT import TFile
-print(">>>   imported ROOT classes after %.1f seconds"%(time.time()-start1))
-
-start1 = time.time()
-from TauFW.PicoProducer.corrections.ScaleFactorTool import *
-print(">>>   imported ScaleFactorTool classes after %.1f seconds"%(time.time()-start1))
-
-start1 = time.time()
-from TauFW.PicoProducer.corrections.MuonSFs import *
-print(">>>   imported MuonSFs classes after %.1f seconds"%(time.time()-start1))
-
-start1 = time.time()
-from TauFW.PicoProducer.corrections.ElectronSFs import *
-print(">>>   imported ElectronSFs classes after %.1f seconds"%(time.time()-start1))
-
-start1 = time.time()
-from TauFW.PicoProducer.corrections.TauTriggerSFs import *
-print(">>>   imported TauTriggerSFs classes after %.1f seconds"%(time.time()-start1))
-
-start1 = time.time()
-from TauFW.PicoProducer.corrections.BTagTool import *
-print(">>>   imported BTagTool classes after %.1f seconds"%(time.time()-start1))
-
-start1 = time.time()
-from TauFW.PicoProducer.corrections.PileupTool import *
-print(">>>   imported PileupTool classes after %.1f seconds"%(time.time()-start1))
-print(">>>   imported everything after %.1f seconds"%(time.time()-start0))
-print(">>> ")
 
 # PATHS
 path       = 'data/lepton/'
 pathHTT_mu = 'data/lepton/HTT/Muon/Run2017/'
 pathHTT_el = 'data/lepton/HTT/Electron/Run2017/'
+maxerr     = 10 # maximum number of errors
 
 # MATRIX
-def printtable(name,method,ptvals=None,etavals=None):
+def printtable(name,method,ptvals=None,etavals=None,etamax=3.0):
   start2 = time.time()
   if ptvals==None:
-    ptvals  = [ 10., 20., 21., 22., 24., 26., 27., 34., 35., 36., 40., 60., 156., 223., 410., 560. ]
+    ptvals  = [ 10., 20., 21., 22., 24., 25., 26., 27., 34., 35., 36., 40., 60., 156., 223., 410., 560. ]
   if etavals==None:
     etavals = [ 0.0, 0.5, 1.1, 1.9, 2.3, 2.4, 2.8, 3.4 ]
     etavals = [-eta for eta in reversed(etavals)]+etavals
+  if etamax!=None:
+    etavals = [eta for eta in etavals if abs(eta)<etamax]
   print(">>>   %s:"%name)
-  TAB = LOG.table("%9.2f"+" %9.2f"*len(etavals)+"  ")
-  #print(">>>    %10s"%('pt\eta')+' '.join('%10.2f'%eta for eta in etavals))
-  TAB.printheader("pt\eta",*[str(eta) for eta in etavals])
+  #TAB = LOG.table("%9.2f"+" %9.2f"*len(etavals)+"  ")
+  #TAB.printheader("pt\eta",*[str(eta) for eta in etavals])
+  print(">>>   "+underline("%10s "%('pt\eta')+' '.join('%9.2f'%eta for eta in etavals)))
+  errors = [ ]
   for pt in ptvals:
     #print(">>>    %10.2f"%(pt)+' '.join('%10.3f'%method(pt,eta) for eta in etavals))
-    TAB.printrow(pt,*[method(pt,eta) for eta in etavals])
-  print(">>>   got %d SFs in %.3f seconds"%(len(ptvals)*len(etavals),time.time()-start2))
+    #TAB.printrow(pt,*[method(pt,eta) for eta in etavals])
+    row = ">>>   %10.2f"%(pt)
+    for eta in etavals:
+      try:
+        row += " %9.2f"%(method(pt,eta))
+      except Exception as error:
+        row += color("     ERROR",'red')
+        errors.append(error)
+    print(row)
+  print(">>>   Got %d SFs in %.3f seconds"%(len(ptvals)*len(etavals),time.time()-start2))
+  if len(errors)>=1:
+    print(">>>   Caught %s error(s):"%(len(errors)))
+    if maxerr>=1:
+      errors = errors[:maxerr]
+    for error in errors:
+      print(">>>     "+color("%s: %r"%(error.__class__.__name__,str(error)),'red'))
   print(">>> ")
   
 
 def muonPOG():
-  LOG.header("muonPOG")
+  LOG.header("muonPOG (ROOT)")
   
   # TRIGGER (Muon POG)
   start1 = time.time()
-  print(">>> initializing trigger SFs from Muon POG...")
+  print(">>> Initializing trigger SFs from Muon POG (ROOT)...")
   sftool_trig = ScaleFactor(path+"MuonPOG/Run2017/EfficienciesAndSF_RunBtoF_Nov17Nov2017.root","IsoMu27_PtEtaBins/abseta_pt_ratio",'mu_trig',ptvseta=True)
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   printtable('trigger POG',sftool_trig.getSF)
   
   # ID (Muon POG)
   start1 = time.time()
   sftool_id  = ScaleFactor(path+"MuonPOG/Run2018/RunABCD_SF_ID.root","NUM_MediumID_DEN_genTracks_pt_abseta",'mu_id',ptvseta=False)
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   printtable('id POG',sftool_id.getSF)
   
   # ISO (Muon POG)
   start1 = time.time()
   sftool_iso = ScaleFactor(path+"MuonPOG/Run2018/RunABCD_SF_ISO.root","NUM_TightRelIso_DEN_MediumID_pt_abseta",'mu_iso',ptvseta=False)
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   printtable('iso POG',sftool_iso.getSF)
   
   # ID/ISO (Muon POG)
   start1 = time.time()
   sftool_idiso    = sftool_id*sftool_iso
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   printtable('idiso POG',sftool_idiso.getSF)  
   print(">>> ")
   
 
 def muonHTT():
-  LOG.header("muonHTT")
+  LOG.header("muonHTT (ROOT)")
   
   # TRIGGER (HTT)
   start1 = time.time()
-  print(">>> initializing trigger SFs from HTT...")
+  print(">>> Initializing trigger SFs from HTT...")
   sftool_mu_trig_HTT = ScaleFactorHTT(pathHTT_mu+"Muon_IsoMu24orIsoMu27.root","ZMass",'mu_idiso')
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   printtable('trigger HTT',sftool_mu_trig_HTT.getSF)
   
   ## ID ISO (HTT)
   #start1 = time.time()
-  #print(">>> initializing idiso SFs from HTT...")
+  #print(">>> Initializing idiso SFs from HTT...")
   #sftool_mu_idiso_HTT = ScaleFactorHTT(pathHTT_mu+"Muon_IdIso_IsoLt0p15_eff_RerecoFall17.root","ZMass",'mu_idiso')
-  #print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  #print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   #printtable('idiso HTT',sftool_mu_idiso_HTT.getSF)
   #print(">>> ")
   
 
 def electronHTT():
-  LOG.header("electronHTT")
+  LOG.header("electronHTT (ROOT)")
   
   # RECO (EGAMMA POG)
   sftool_ele_reco_HTT = ScaleFactor(pathHTT_el+"egammaEffi.txt_EGM2D_runBCDEF_passingRECO.root","EGamma_SF2D",'ele_reco',ptvseta=True)
@@ -122,25 +109,14 @@ def electronHTT():
   printtable('idiso HTT',sftool_ele_idiso_HTT.getSF)
   
 
-def muonSFs():
-  LOG.header("muonSFs")
+def muonSFs_JSON(era='UL2018'):
+  LOG.header("muonSFs (JSON)")
   
   # MUON SFs
   start1 = time.time()
-  print(">>> initializing MuonSF object...")
-  muSFs = MuonSFs()
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
-  
-  # GET SFs
-  printtable('trigger',muSFs.getTriggerSF)
-  printtable('idiso',muSFs.getIdIsoSF)
-  print(">>> ")
-  
-  # MUON 2018 SFs
-  start1 = time.time()
-  print(">>> initializing MuonSF(2018) object...")
-  muSFs = MuonSFs(year=2018)
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>> Initializing MuonSF object for era=%r..."%(era))
+  muSFs = MuonSFs(era)
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   
   # GET SFs
   printtable('trigger',muSFs.getTriggerSF)
@@ -148,15 +124,30 @@ def muonSFs():
   print(">>> ")
   
 
-def electronSFs():
+def muonSFs_ROOT(era='UL2018'):
+  LOG.header("muonSFs (ROOT)")
+  
+  # MUON SFs
+  start1 = time.time()
+  print(">>> Initializing MuonSF object for era=%r..."%(era))
+  muSFs = MuonSFs_ROOT(era)
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
+  
+  # GET SFs
+  printtable('trigger',muSFs.getTriggerSF)
+  printtable('idiso',muSFs.getIdIsoSF)
+  print(">>> ")
+  
+
+def electronSFs(era='UL2019'):
   LOG.header("electronSFs")
   
   # ELECTRON SFs
   print(">>> ")
   start1 = time.time()
-  print(">>> initializing ElectronSFs object...")
-  eleSFs = ElectronSFs()
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>> Initializing ElectronSFs object for era=%s..."%(era))
+  eleSFs = ElectronSFs(era)
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   
   # GET SFs
   printtable('trigger',eleSFs.getTriggerSF)
@@ -177,34 +168,34 @@ def tauTriggerSFs():
   printtable('trigger fake',lambda p,d: tauSFs.getSF(p,d),ptvals=ptvals,etavals=dmvals)
   
 
-def btagSFs(tagger='CSVv2'):
+def btagSFs(tagger='DeepCSV'):
   LOG.header("btagSFs")
   
   # BTAG SFs
   print(">>> ")
   start1 = time.time()
-  print(">>> initializing BTagWeightTool(%r) object..."%tagger)
+  print(">>> Initializing BTagWeightTool(%r) object..."%tagger)
   btagSFs = BTagWeightTool(tagger)
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   
   # GET SFs
-  printtable('%s g'%tagger,lambda p,e: btagSFs.getSF(p,e,0,True))
-  #printtable('%s u'%tagger,lambda p,e: btagSFs.getSF(p,e,1,True))
-  #printtable('%s d'%tagger,lambda p,e: btagSFs.getSF(p,e,2,True))
-  #printtable('%s s'%tagger,lambda p,e: btagSFs.getSF(p,e,3,True))
-  printtable('%s c'%tagger,lambda p,e: btagSFs.getSF(p,e,4,True))
-  printtable('%s b'%tagger,lambda p,e: btagSFs.getSF(p,e,5,True))
+  printtable('%s g'%tagger,lambda p,e: btagSFs.getSF(p,e,0,True),etamax=5)
+  #printtable('%s u'%tagger,lambda p,e: btagSFs.getSF(p,e,1,True),etamax=5)
+  #printtable('%s d'%tagger,lambda p,e: btagSFs.getSF(p,e,2,True),etamax=5)
+  #printtable('%s s'%tagger,lambda p,e: btagSFs.getSF(p,e,3,True),etamax=5)
+  printtable('%s c'%tagger,lambda p,e: btagSFs.getSF(p,e,4,True),etamax=5)
+  printtable('%s b'%tagger,lambda p,e: btagSFs.getSF(p,e,5,True),etamax=5)
   
 
-def pileupSFs(era='UL2017'):
+def pileupSFs(era='UL2018'):
   LOG.header("pileupSFs")
   
   # PILE UP TOOL
   print(">>> ")
   start1 = time.time()
-  print(">>> initializing PileupTool(%r) object..."%era)
+  print(">>> Initializing PileupTool(%r) object..."%era)
   puTool = PileupWeightTool(era)
-  print(">>>   initialized in %.1f seconds"%(time.time()-start1))
+  print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   
   ## GET SFs
   start2 = time.time()
@@ -213,21 +204,108 @@ def pileupSFs(era='UL2017'):
   npus = [0,1,2,5,10,15,18,20,24,25,26,28,30,35,40,50,60,70,80,100]
   for npu in npus:
     TAB.printrow(npu,puTool.getWeight(npu))
-  print(">>>   got %d SFs in %.3f seconds"%(len(npus),time.time()-start2))
+  print(">>>   Got %d SFs in %.3f seconds"%(len(npus),time.time()-start2))
+  
+
+def main(args):
+  tools = args.tools
+  eras  = args.eras
+  
+  # LEPTON SF
+  if not tools or 'musf' in tools:
+    muonPOG()
+    muonHTT()
+  if not tools or 'elesf' in tools:
+    electronHTT()
+  if not tools or 'mu' in tools:
+    for era in eras:
+      muonSFs_JSON(era)
+    for era in eras:
+      muonSFs_ROOT(era)
+  if not tools or 'ele' in tools:
+    electronSFs()
+  
+  # TAU
+  if not tools or 'tau' in tools:
+    tauTriggerSFs()
+  
+  # BTV
+  if not tools or 'btag' in tools:
+    #btagSFs('CSVv2')
+    btagSFs('DeepCSV')
+  
+  # PU
+  if not tools or 'pu' in tools:
+    for era in eras:
+      pileupSFs(era)
   
 
 if __name__ == "__main__":
+  from argparse import ArgumentParser
+  description = """Test corrections tools"""
+  parser = ArgumentParser(description=description,epilog="Good luck!")
+  parser.add_argument('-t','--tool',    dest='tools', nargs='+',
+                                        help="corrections tools to test" )
+  parser.add_argument('-y','--era',     dest='eras', nargs='+', default=['UL2018'],
+                                        help="eras to run" )
+  parser.add_argument('-m','--maxerr',  dest='maxerr', type=int, default=10,
+                                        help="maximum nubmer of errors to print" )
+  parser.add_argument('-v','--verbose', dest='verbosity', type=int, nargs='?', const=1, default=0, action='store',
+                                        help="set verbosity level" )
+  args   = parser.parse_args()
+  tools  = args.tools
+  maxerr = args.maxerr
   
-  muonPOG()
-  #muonHTT()
-  #electronHTT()
-  #muonSFs()
-  electronSFs()
-  tauTriggerSFs()
-  #btagSFs('CSVv2')
-  btagSFs('DeepCSV')
-  pileupSFs('2017')
-  pileupSFs('UL2017')
+  # IMPORTS
+  start1 = time.time()
+  from ROOT import TFile # typically slows down other modules
+  print(">>>   Imported ROOT classes after %.1f seconds"%(time.time()-start1))
+  
+  if any(s in tools for s in ['musf','elesf']):
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.ScaleFactorTool import *
+    print(">>>   Imported ScaleFactorTool classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'mu' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.MuonSFs import *
+    print(">>>   Imported MuonSFs classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'mu' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.MuonSFs_ROOT import MuonSFs as MuonSFs_ROOT
+    print(">>>   Imported MuonSFs_ROOT classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'ele' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.ElectronSFs import *
+    print(">>>   Imported ElectronSFs classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'tau' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.TauTriggerSFs import *
+    print(">>>   Imported TauTriggerSFs classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'btag' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.BTagTool import *
+    print(">>>   Imported BTagTool classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'pu' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.PileupTool import *
+    print(">>>   Imported PileupTool classes after %.1f seconds"%(time.time()-start1))
+  
+  if 'jetveto' in tools:
+    start1 = time.time()
+    from TauFW.PicoProducer.corrections.JetVetoMapTool import *
+    print(">>>   Imported JetVetoMapTool classes after %.1f seconds"%(time.time()-start1))
+    
+  print(">>>   Imported everything after %.1f seconds"%(time.time()-start0))
   print(">>> ")
-  print(">>> done after %.1f seconds"%(time.time()-start0))
+  
+  # MAIN FUNCTIONALITY
+  main(args)
+  print(">>> ")
+  print(">>> Done after %.1f seconds"%(time.time()-start0))
   print('')

--- a/PicoProducer/test/testSFs.py
+++ b/PicoProducer/test/testSFs.py
@@ -13,15 +13,19 @@ path       = 'data/lepton/'
 pathHTT_mu = 'data/lepton/HTT/Muon/Run2017/'
 pathHTT_el = 'data/lepton/HTT/Electron/Run2017/'
 maxerr     = 10 # maximum number of errors
+neta       = True # include negative eta
+ptvals_    = [ 10., 20., 21., 22., 24., 25., 26., 27., 34., 35., 36., 40., 60., 156., 223., 410., 560. ]
+etavals_   = [ 0.0, 0.5, 1.1, 1.9, 2.3, 2.4, 2.8, 3.4 ]
 
 # MATRIX
 def printtable(name,method,ptvals=None,etavals=None,etamax=3.0):
   start2 = time.time()
   if ptvals==None:
-    ptvals  = [ 10., 20., 21., 22., 24., 25., 26., 27., 34., 35., 36., 40., 60., 156., 223., 410., 560. ]
+    ptvals  = ptvals_
   if etavals==None:
-    etavals = [ 0.0, 0.5, 1.1, 1.9, 2.3, 2.4, 2.8, 3.4 ]
-    etavals = [-eta for eta in reversed(etavals)]+etavals
+    etavals = etavals_
+    if neta:
+      etavals = [-eta for eta in reversed(etavals) if eta>0]+etavals # add negative values
   if etamax!=None:
     etavals = [eta for eta in etavals if abs(eta)<etamax]
   print(">>>   %s:"%name)
@@ -253,11 +257,22 @@ if __name__ == "__main__":
                                         help="eras to run" )
   parser.add_argument('-m','--maxerr',  dest='maxerr', type=int, default=10,
                                         help="maximum nubmer of errors to print" )
+  parser.add_argument('-e','--eta',     dest='etavals', type=float, nargs='+',
+                                        help="etas to check" )
+  parser.add_argument('-p','--pt',      dest='ptvals', type=float, nargs='+',
+                                        help="pt vals to check" )
+  parser.add_argument('-n','--neta',    dest='neta', action='store_false',
+                                        help="no negative eta" )
   parser.add_argument('-v','--verbose', dest='verbosity', type=int, nargs='?', const=1, default=0, action='store',
                                         help="set verbosity level" )
-  args   = parser.parse_args()
-  tools  = args.tools
-  maxerr = args.maxerr
+  args     = parser.parse_args()
+  tools    = args.tools
+  maxerr   = args.maxerr
+  neta     = args.neta
+  if args.ptvals:
+    ptvals_  = args.ptvals
+  if args.etavals:
+    etavals_ = args.etavals
   
   # IMPORTS
   start1 = time.time()

--- a/PicoProducer/test/testSFs.py
+++ b/PicoProducer/test/testSFs.py
@@ -170,14 +170,14 @@ def tauTriggerSFs():
   printtable('trigger fake',lambda p,d: tauSFs.getSF(p,d),ptvals=ptvals,etavals=dmvals)
   
 
-def btagSFs(tagger='DeepCSV'):
+def btagSFs(era='UL2018',tagger='DeepJet'):
   LOG.header("btagSFs")
   
   # BTAG SFs
   print(">>> ")
   start1 = time.time()
-  print(">>> Initializing BTagWeightTool(%r) object..."%tagger)
-  btagSFs = BTagWeightTool(tagger)
+  print(">>> Initializing BTagWeightTool(%r,%r) object..."%(tagger,era))
+  btagSFs = BTagWeightTool(tagger,wp='medium',era=era,channel='mutau')
   print(">>>   Initialized in %.1f seconds"%(time.time()-start1))
   
   # GET SFs
@@ -234,8 +234,8 @@ def main(args):
   
   # BTV
   if not tools or 'btag' in tools:
-    #btagSFs('CSVv2')
-    btagSFs('DeepCSV')
+    for era in eras:
+      btagSFs(era=era,tagger='DeepJet')
   
   # PU
   if not tools or 'pu' in tools:

--- a/PicoProducer/test/testSFs.py
+++ b/PicoProducer/test/testSFs.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 # Author: Izaak Neutelings (December 2018)
+# Instructions:
+#   python3 test/testSFs.py -t mu -m 2 -y UL2016_post UL2016_pre UL2017 UL2018 2022_pre 2022_post 2023C 2023D
 import time
 start0 = time.time()
 print(">>> Importing modules...")
@@ -220,6 +222,7 @@ def main(args):
   if not tools or 'mu' in tools:
     for era in eras:
       muonSFs_JSON(era)
+  if not tools or 'muroot' in tools:
     for era in eras:
       muonSFs_ROOT(era)
   if not tools or 'ele' in tools:
@@ -271,7 +274,7 @@ if __name__ == "__main__":
     from TauFW.PicoProducer.corrections.MuonSFs import *
     print(">>>   Imported MuonSFs classes after %.1f seconds"%(time.time()-start1))
   
-  if 'mu' in tools:
+  if 'muroot' in tools:
     start1 = time.time()
     from TauFW.PicoProducer.corrections.MuonSFs_ROOT import MuonSFs as MuonSFs_ROOT
     print(">>>   Imported MuonSFs_ROOT classes after %.1f seconds"%(time.time()-start1))

--- a/common/python/tools/log.py
+++ b/common/python/tools/log.py
@@ -163,6 +163,8 @@ class Logger(object):
     """Fatal error by throwing a specified exception."""
     if trigger:
       string = color(string,'red',**kwargs)
+      if isinstance(error,Exception):
+        error = error.__class__
       raise error(string)
     return trigger
   


### PR DESCRIPTION
Long time coming: correctionlib JSONs.

For now only muon SFs, as it seems ROOT files are no longer supported starting for 2023 data, and we need these for the TauPOG SF measurements. Other corrections like electron SFs, pileup reweighting, b tagging SFs, etc. should also be done soon!

The old ROOT-based muon SF tool is preserved as `MuonSFs_ROOT`.

> [!WARNING]
> * correctionlib is only available in python3, so the muon SFs will not be supported anymore in the TauFW for  **CMSSW 11 and older** once this PR is merged.
> * The muon corretionlib JSONs throw runtime errors if the pt or eta is out of range, so user need to make sure they are applying the MuonPOG's recommended pt/eta cuts, e.g, pt>26 for `IsoMu24` and `abs(eta)<2.4`, etc.

# Installation
Instructions are added to the wiki:
https://github.com/cms-tau-pog/TauFW/wiki/Installation#corrections
```
# clone from GitLab
cd $CMSSW_BASE/src/TauFW/PicoProducer
git clone ssh://git@gitlab.cern.ch:7999/cms-nanoAOD/jsonpog-integration.git data/jsonpog

# OR copy them from CVMFS:
cd $CMSSW_BASE/src/TauFW/PicoProducer
cp -rv /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration data/jsonpog
```

# Validation
Tested with:
```bash
cd $CMSSW_BASE/src/TauFW/PicoProducer
python3 test/testSFs.py -t mu -m 2 -y UL2016_post UL2016_pre UL2017 UL2018 2022_pre 2022_post 2023C 2023D

pico.py era UL2018 tutorial/samples_UL2018.py
pico.py channel mutau 'tutorial.ModuleMuTau jec=False'
pico.py run -c mutau -y UL2018 -m 10000
```
I did some quick checks for a couple of eras, and the SFs look mostly consistent between the old JSONs and ROOT.

# @
Can you quickly review & sign off, @pmastrap @saswatinandan, please?