### PR TITLE
Fix bug in resubmission: avoid mixing nominal and variations

### DIFF
--- a/PicoProducer/python/batch/utils.py
+++ b/PicoProducer/python/batch/utils.py
@@ -157,6 +157,7 @@ def getcfgsamples(jobcfgnames,filter=[ ],veto=[ ],dtype=[ ],verb=0):
       if sample.paths!=osample.paths: continue
       if sample.channels[0] not in osample.channels: continue
       if sample.subtry>osample.subtry: # ensure last job (re)submission
+        #TODO: compare sample.jobcfg['config'] and osample.jobcfg['config'] to avoid mixing different jobs
         samples[samples.index(osample)] = sample # replace
       break
     else: # if no break

--- a/PicoProducer/python/pico/job.py
+++ b/PicoProducer/python/pico/job.py
@@ -84,7 +84,7 @@ def preparejobs(args):
       if resubmit: # get samples from existing job config files
         # TODO: allow user to resubmit given config file
         jobdir_ = repkey(jobdirformat,ERA=era,SAMPLE='*',CHANNEL=channel,TAG=tag)
-        jobcfgs = repkey(os.path.join(jobdir_,"config/jobconfig_$SAMPLE$TAG_try[0-9]*.json"),
+        jobcfgs = repkey(os.path.join(jobdir_,"config/jobconfig_$CHANNEL$TAG_try[0-9]*.json"),
                          ERA=era,SAMPLE='*',CHANNEL=channel,TAG=tag)
         if verbosity>=2:
           print(">>> %-12s = %s"%('cwd',os.getcwd()))


### PR DESCRIPTION
Fixing bug reported by @saswatinandan, which was caused by line https://github.com/cms-tau-pog/TauFW/blob/844b7d415f2d20e2195061b79149923030d23077/PicoProducer/python/pico/job.py#L87-L88
Here, if you want to resubmit a nominal sample with `tag=""`,
```python
"config/jobconfig_$SAMPLE$TAG_try[0-9]*.json"
```
was replaced to
```python
"config/jobconfig_*_try[0-9]*.json"
```
However, this wildcard wil capture the config jsons of local variations like `config/jobconfig_mutau_JTFDown_try6.json`, which is actually for `tag="_JTFDown"`. The algorithm in `getcfgsamples` wil pick the config JSON file with the largest `try`. This leads to conflicts...

There should be no wildcard there to avoid mixing different run in the same output directory, and it should actually be
```python
"config/jobconfig_$CHANNEL$TAG_try[0-9]*.json"
```
So for `tag=""`, you get strictly
```python
"config/jobconfig_mutau_try[0-9]*.json"
```
and for `tag="_JTFDown"`, you get
```python
"config/jobconfig_mutau_JTFDown_try[0-9]*.json"
```