### PR TITLE
CMSSW 14 compatibility

### DIFF
--- a/PicoProducer/python/__init__.py
+++ b/PicoProducer/python/__init__.py
@@ -1,4 +1,8 @@
 # Author: Izaak Neutelings (May 2020)
 import os
-basedir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if 'CMSSW_BASE' in os.environ: # look for $CMSSW_BASE/src/TauFW/PicoProducer
+  basedir = os.path.join(os.environ['CMSSW_BASE'],"src/TauFW/PicoProducer")
+else: # expand symlink
+  basedir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+assert os.path.exists(basedir), f"Could not parse PicoProducer's basedir={basedir}"
 datadir = os.path.join(basedir,'data')

--- a/PicoProducer/python/batch/submit_HTCondor.sub
+++ b/PicoProducer/python/batch/submit_HTCondor.sub
@@ -23,7 +23,9 @@ getenv                = CMSSW*, SCRAM_ARCH*, *CONTAINER
 environment           = "JOBID=$(ClusterId) TASKID=$(ProcId) CONTAINER=$(container)"
 # NOTE: The following OS requirement should be replaced for CMSSW 13 & later,
 #       or replaced with singularities all together when CentOS7 is phased out on lxplus
-requirements          = (OpSysAndVer =?= "CentOS7")
+#       See https://batchdocs.web.cern.ch/local/submit.html#os-choice
+#requirements          = (OpSysAndVer =?= "CentOS7")
+#requirements          = (OpSysAndVer =?= "AlmaLinux9")
 +JobFlavour           = workday
 +MaxRuntime           = 20000
 #queue arg from args.txt


### PR DESCRIPTION
Several changes for compatibility with CMSSW 13/14 on EL9/AlmaLinux9.
* Change assignment of PicoProducer path: For some reason CMSSW 13 and newer do not create symlinks for `__init__.py` in the top directories anymore (`$CMSSW_BASE/python/TauFW/PicoProducer/__init__.py` → `$CMSSW_BASE/src/TauFW/PicoProducer/python/__init__.py`). Guess path based on `CMSSW_BASE` environmental variable by default.
* Remove requirement of HTCondor node. Although I am not sure if this will break other use cases, CERN documentation seems to state AlmaLinux9 is anyway default at the moment: https://batchdocs.web.cern.ch/local/submit.html#os-choice